### PR TITLE
Do not start container until after attach. Do not attach if container never starts.

### DIFF
--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -501,7 +501,13 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Unable to wait container end of execution: %s", err)
 				}
-			case <-attachCh:
+			case res := <-attachCh:
+				if res.Error != nil {
+					return fmt.Errorf("container exited with error code %v: %v", res.StatusCode, res.Error.Message)
+				}
+				if res.StatusCode != 0 {
+					return fmt.Errorf("container exited with non-zero code %v", res.StatusCode)
+				}
 				if d.Get("logs").(bool) {
 					d.Set("container_logs", b.String())
 				}

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -458,52 +458,57 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 	if d.Get("start").(bool) {
 		creationTime = time.Now()
 		options := types.ContainerStartOptions{}
-		if err := client.ContainerStart(context.Background(), retContainer.ID, options); err != nil {
-			return fmt.Errorf("Unable to start container: %s", err)
-		}
-	}
+		if d.Get("attach").(bool) {
+			var b bytes.Buffer
 
-	if d.Get("attach").(bool) {
-		var b bytes.Buffer
+			ctx := context.Background()
 
-		ctx := context.Background()
-
-		if d.Get("logs").(bool) {
-			go func() {
-				reader, err := client.ContainerLogs(ctx, retContainer.ID, types.ContainerLogsOptions{
-					ShowStdout: true,
-					ShowStderr: true,
-					Follow:     true,
-					Timestamps: false,
-				})
-				if err != nil {
-					log.Panic(err)
-				}
-				defer reader.Close()
-
-				scanner := bufio.NewScanner(reader)
-				for scanner.Scan() {
-					line := scanner.Text()
-					b.WriteString(line)
-					b.WriteString("\n")
-
-					log.Printf("[DEBUG] container logs: %s", line)
-				}
-				if err := scanner.Err(); err != nil {
-					log.Fatal(err)
-				}
-			}()
-		}
-
-		attachCh, errAttachCh := client.ContainerWait(ctx, retContainer.ID, container.WaitConditionNotRunning)
-		select {
-		case err := <-errAttachCh:
-			if err != nil {
-				return fmt.Errorf("Unable to wait container end of execution: %s", err)
-			}
-		case <-attachCh:
 			if d.Get("logs").(bool) {
-				d.Set("container_logs", b.String())
+				go func() {
+					reader, err := client.ContainerLogs(ctx, retContainer.ID, types.ContainerLogsOptions{
+						ShowStdout: true,
+						ShowStderr: true,
+						Follow:     true,
+						Timestamps: false,
+					})
+					if err != nil {
+						log.Panic(err)
+					}
+					defer reader.Close()
+
+					scanner := bufio.NewScanner(reader)
+					for scanner.Scan() {
+						line := scanner.Text()
+						b.WriteString(line)
+						b.WriteString("\n")
+
+						log.Printf("[DEBUG] container logs: %s", line)
+					}
+					if err := scanner.Err(); err != nil {
+						log.Fatal(err)
+					}
+				}()
+			}
+
+			attachCh, errAttachCh := client.ContainerWait(ctx, retContainer.ID, container.WaitConditionNotRunning)
+
+			if err := client.ContainerStart(context.Background(), retContainer.ID, options); err != nil {
+				return fmt.Errorf("Unable to start container: %s", err)
+			}
+
+			select {
+			case err := <-errAttachCh:
+				if err != nil {
+					return fmt.Errorf("Unable to wait container end of execution: %s", err)
+				}
+			case <-attachCh:
+				if d.Get("logs").(bool) {
+					d.Set("container_logs", b.String())
+				}
+			}
+		} else {
+			if err := client.ContainerStart(context.Background(), retContainer.ID, options); err != nil {
+				return fmt.Errorf("Unable to start container: %s", err)
 			}
 		}
 	}

--- a/docker/resource_docker_container_funcs.go
+++ b/docker/resource_docker_container_funcs.go
@@ -503,10 +503,10 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 				}
 			case res := <-attachCh:
 				if res.Error != nil {
-					return fmt.Errorf("container exited with error code %v: %v", res.StatusCode, res.Error.Message)
+					return fmt.Errorf("container %v exited with error code %v: %v", retContainer.ID, res.StatusCode, res.Error.Message)
 				}
 				if res.StatusCode != 0 {
-					return fmt.Errorf("container exited with non-zero code %v", res.StatusCode)
+					return fmt.Errorf("container %v exited with non-zero code %v", retContainer.ID, res.StatusCode)
 				}
 				if d.Get("logs").(bool) {
 					d.Set("container_logs", b.String())

--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -1379,6 +1379,10 @@ func TestAccDockerContainer_attach(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccDockerContainer_attach_race(t *testing.T) {
+	var c types.ContainerJSON
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },


### PR DESCRIPTION
This deals with a race condition that causes an error when the container starts and exits before the provider can attach.