### PR TITLE
ci: update ubuntu images and docker version

### DIFF
--- a/.github/workflows/acc-test.yaml
+++ b/.github/workflows/acc-test.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:20.04
     strategy:
       fail-fast: true
     steps:

--- a/.github/workflows/acc-test.yaml
+++ b/.github/workflows/acc-test.yaml
@@ -15,6 +15,7 @@ on:
 env:
   GO_VERSION: "1.15"
   GOPROXY: https://gocenter.io,https://proxy.golang.org,direct
+  DEBIAN_FRONTEND: noninteractive
 
 jobs:
   test:
@@ -28,27 +29,14 @@ jobs:
           go-version: '1.15'
       - run: cat /etc/issue
       - run: bash scripts/gogetcookie.sh
-      # locally: docker run -it ubuntu:bionic bash (https://ubuntu.pkgs.org/18.04/docker-ce-stable-amd64/)
+      # locally: docker run -it ubuntu:20.04 bash (https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/)
       - run: sudo apt-get update
       - run: sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
       - run: curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
       - run: sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
       - run: sudo apt-get update
-      # apt-cache policy docker-ce 
-      - run: sudo apt-get -y install docker-ce=5:19.03.5~3-0~ubuntu-bionic
-      - run: docker version
-      # Allow local registry to be insecure
-      - run: sudo sed 's/DOCKER_OPTS="/DOCKER_OPTS="--insecure-registry=127.0.0.1:15000 /g' -i /etc/default/docker
-      - run: sudo cat /etc/default/docker
-      - run: sudo service docker restart
-            # locally: docker run -it ubuntu:bionic bash (https://ubuntu.pkgs.org/18.04/docker-ce-stable-amd64/)
-      - run: sudo apt-get update
-      - run: sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-      - run: curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-      - run: sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-      - run: sudo apt-get update
-      # apt-cache policy docker-ce 
-      - run: sudo apt-get -y install docker-ce=5:19.03.5~3-0~ubuntu-bionic
+      # list available docker versions: apt-cache policy docker-ce 
+      - run: sudo apt-get -y install docker-ce=5:20.10.1~3-0~ubuntu-focal
       - run: docker version
       # Allow local registry to be insecure
       - run: sudo sed 's/DOCKER_OPTS="/DOCKER_OPTS="--insecure-registry=127.0.0.1:15000 /g' -i /etc/default/docker

--- a/.github/workflows/acc-test.yaml
+++ b/.github/workflows/acc-test.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu:20.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
     steps:
@@ -29,7 +29,7 @@ jobs:
           go-version: '1.15'
       - run: cat /etc/issue
       - run: bash scripts/gogetcookie.sh
-      # locally: docker run -it ubuntu:20.04 bash (https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/)
+      # locally: docker run -it ubuntu-20.04 bash (https://ubuntu.pkgs.org/20.04/docker-ce-stable-amd64/)
       - run: sudo apt-get update
       - run: sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
       - run: curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:20.04
     strategy:
       fail-fast: true
     steps:

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu:20.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
     steps:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu:20.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
       - "v*"
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
       - "v*"
 jobs:
   goreleaser:
-    runs-on: ubuntu:20.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:20.04
     strategy:
       fail-fast: true
     steps:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu:20.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
     steps:

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
@@ -27,7 +27,7 @@ jobs:
           folder-path: 'website/docs'
           file-extension: '.markdown'
   markdown-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       - uses: avto-dev/markdown-lint@v1

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu:20.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
@@ -27,7 +27,7 @@ jobs:
           folder-path: 'website/docs'
           file-extension: '.markdown'
   markdown-lint:
-    runs-on: ubuntu:20.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: avto-dev/markdown-lint@v1


### PR DESCRIPTION
- implements #5 
- adds `ubuntu:20.04` as image for all workflows
- bumps docker version to `20.10.1`