### PR TITLE
fix: set "latest" tag when tag isn't specified

### DIFF
--- a/docker/resource_docker_image_funcs.go
+++ b/docker/resource_docker_image_funcs.go
@@ -264,6 +264,10 @@ func parseImageOptions(image string) internalPullImageOptions {
 		pullOpts.Tag = image[prefixLength+tagIndex+1:]
 	}
 
+	if pullOpts.Tag == "" {
+		pullOpts.Tag = "latest"
+	}
+
 	return pullOpts
 }
 


### PR DESCRIPTION
Close #116 

https://github.com/kreuzwerker/terraform-provider-docker/blob/5f2ed87b8ff668445738f2c9992cb1e6b08532ff/docker/resource_docker_registry_image_funcs.go#L457

When `pullOpts.Tag` is empty, `FqName` is invalid format `%s/%s:`.

## Test

```
$ terraform version
Terraform v0.13.5
+ provider registry.terraform.io/kreuzwerker/docker v2.9.0
```

```tf
resource "docker_registry_image" "eshopwebmvc" {
  name = "suzukishunsuke/test"

  build {
    context = "."
  }
}
```

Dockerfile

```dockerfile
FROM alpine:3.11.6
```

### AS IS

```
$ terraform apply
```

```
Error: Error building docker image: Error response from daemon: invalid reference format
```

<details>

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # docker_registry_image.eshopwebmvc will be created
  + resource "docker_registry_image" "eshopwebmvc" {
      + id            = (known after apply)
      + keep_remotely = false
      + name          = "suzukishunsuke/test"
      + sha256_digest = (known after apply)

      + build {
          + context    = ".:8fffdc288f367f3686c3e5f35cce89a9848e75efb0de71aeec67209d7c4a43c7"
          + dockerfile = "Dockerfile"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

docker_registry_image.eshopwebmvc: Creating...

Error: Error building docker image: Error response from daemon: invalid reference format

  on main.tf line 19, in resource "docker_registry_image" "eshopwebmvc":
  19: resource "docker_registry_image" "eshopwebmvc" {
```

</details>

### TO BE

```
$ terraform apply
```

```
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

<details>

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # docker_registry_image.eshopwebmvc will be created
  + resource "docker_registry_image" "eshopwebmvc" {
      + id            = (known after apply)
      + keep_remotely = false
      + name          = "suzukishunsuke/test"
      + sha256_digest = (known after apply)

      + build {
          + context    = ".:815ed2590ead7bbd8a61066d5b80ddf72c6db697bd0d36bac13e71f102791d5b"
          + dockerfile = "Dockerfile"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

docker_registry_image.eshopwebmvc: Creating...
docker_registry_image.eshopwebmvc: Still creating... [10s elapsed]
docker_registry_image.eshopwebmvc: Creation complete after 17s [id=sha256:39eda93d15866957feaee28f8fc5adb545276a64147445c64992ef69804dbf01]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

</details>