### PR TITLE
docs: fix legacy configuration style

### DIFF
--- a/docker/resource_docker_container_test.go
+++ b/docker/resource_docker_container_test.go
@@ -960,12 +960,12 @@ func TestAccDockerContainer_multipleUploadContentsConfig(t *testing.T) {
 				
 				resource "docker_container" "foo" {
 					name     = "tf-test"
-					image    = "${docker_image.foo.latest}"
+					image    = docker_image.foo.latest
 					must_run = "false"
 				
 					upload {
 						content        = "foobar"
-						content_base64 = "${base64encode("barbaz")}"
+						content_base64 = base64encode("barbaz")
 						file           = "/terraform/test1.txt"
 						executable     = true
 					}
@@ -991,7 +991,7 @@ func TestAccDockerContainer_noUploadContentsConfig(t *testing.T) {
 				
 				resource "docker_container" "foo" {
 					name     = "tf-test"
-					image    = "${docker_image.foo.latest}"
+					image    = docker_image.foo.latest
 					must_run = "false"
 				
 					upload {
@@ -1793,7 +1793,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 }
 `
 
@@ -1804,7 +1804,7 @@ resource "docker_image" "fooinit" {
 
 resource "docker_container" "fooinit" {
 	name = "tf-test"
-	image = "${docker_image.fooinit.latest}"
+	image = docker_image.fooinit.latest
 	init = true
 }
 `
@@ -1816,7 +1816,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	restart = "on-failure"
 	max_retry_count = 5
@@ -1842,10 +1842,10 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name  	 = "tf-test"
-	image 	 = "${docker_image.foo.latest}"
+	image 	 = docker_image.foo.latest
 	networks = [
-		"${docker_network.tftest.name}",
-		"${docker_network.tftest_2.name}"
+		docker_network.tftest.name,
+		docker_network.tftest_2.name
 	]
 }
 `
@@ -1861,10 +1861,10 @@ resource "docker_volume" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
     volumes {
-        volume_name = "${docker_volume.foo.name}"
+        volume_name = docker_volume.foo.name
         container_path = "/tmp/volume"
         read_only = false
     }
@@ -1882,11 +1882,11 @@ resource "docker_volume" "foo_mounts" {
 
 resource "docker_container" "foo_mounts" {
 	name = "tf-test"
-	image = "${docker_image.foo_mounts.latest}"
+	image = docker_image.foo_mounts.latest
 
 	mounts {
 		target      = "/mount/test"
-		source      = "${docker_volume.foo_mounts.name}"
+		source      = docker_volume.foo_mounts.name
 		type        = "volume"
 		read_only   = true
 	}
@@ -1904,7 +1904,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	tmpfs = {
 		"/mount/tmpfs" = "rw,noexec,nosuid"
@@ -1919,7 +1919,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 	entrypoint = ["/bin/bash", "-c", "ping localhost"]
 	user = "root:root"
 	restart = "on-failure"
@@ -1961,7 +1961,7 @@ resource "docker_container" "foo" {
 	network_mode = "bridge"
 
 	networks_advanced {
-		name = "${docker_network.test_network.name}"
+		name = docker_network.test_network.name
 		aliases = ["tftest"]
 	}
 
@@ -2006,7 +2006,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	upload {
 		content = "foo"
@@ -2024,7 +2024,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	upload {
 		source = "%s"
@@ -2042,7 +2042,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	upload {
 		source = "%s"
@@ -2061,10 +2061,10 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name  = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	upload {
-		content_base64 = "${base64encode("894fc3f56edf2d3a4c5fb5cb71df910f958a2ed8")}"
+		content_base64 = base64encode("894fc3f56edf2d3a4c5fb5cb71df910f958a2ed8")
 		file           = "/terraform/test1.txt"
 		executable     = true
 	}
@@ -2083,7 +2083,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	devices {
     	host_path = "/dev/zero"
@@ -2101,7 +2101,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	ports {
 		internal = 80
@@ -2117,7 +2117,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	ports {
 		internal = 80
@@ -2137,7 +2137,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	ports {
 		internal = 80
@@ -2154,7 +2154,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	ports {
 		internal = 80
@@ -2185,17 +2185,17 @@ resource "docker_network" "test_network_2" {
 
 resource "docker_container" "foo" {
   name          = "tf-test"
-  image         = "${docker_image.foo.latest}"
-  network_mode  = "${docker_network.test_network_1.name}"
-  networks      = ["${docker_network.test_network_2.name}"]
+  image         = docker_image.foo.latest
+  network_mode  = docker_network.test_network_1.name
+  networks      = [docker_network.test_network_2.name]
   network_alias = ["tftest-container"]
 }
 
 resource "docker_container" "bar" {
   name          = "tf-test-bar"
-  image         = "${docker_image.foo.latest}"
+  image         = docker_image.foo.latest
   network_mode  = "bridge"
-  networks      = ["${docker_network.test_network_2.name}"]
+  networks      = [docker_network.test_network_2.name]
   network_alias = ["tftest-container-foo"]
 }
 `
@@ -2208,7 +2208,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
   name  = "tf-test"
-  image = "${docker_image.foo.latest}"
+  image = docker_image.foo.latest
 
   healthcheck {
     test         = ["CMD", "/bin/true"]
@@ -2247,9 +2247,9 @@ resource "docker_image" "foo" {
 }
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 	networks_advanced {
-		name = "${docker_network.test.name}"
+		name = docker_network.test.name
 		ipv4_address = "10.0.1.123"
 	}
 }
@@ -2270,9 +2270,9 @@ resource "docker_image" "foo" {
 }
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 	networks_advanced {
-		name = "${docker_network.test.name}"
+		name = docker_network.test.name
 		ipv6_address = "fd00:0:0:0::123"
 	}
 }
@@ -2297,9 +2297,9 @@ resource "docker_image" "foo" {
 }
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 	networks_advanced {
-		name = "${docker_network.test.name}"
+		name = docker_network.test.name
 		ipv4_address = "10.0.1.123"
 		ipv6_address = "fd00:0:0:0::123"
 	}
@@ -2313,7 +2313,7 @@ resource "docker_image" "foo" {
 }
  resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 	command = ["/bin/sleep", "15"]
 	rm = true
 }
@@ -2326,7 +2326,7 @@ resource "docker_image" "foo" {
 }
  resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 	command = ["/bin/sleep", "15"]
 	read_only = true
 }
@@ -2339,7 +2339,7 @@ resource "docker_image" "foo" {
 }
  resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 	command = ["/bin/sh", "-c", "for i in $(seq 1 15); do sleep 1; done"]
 	attach = true
 	must_run = false
@@ -2354,7 +2354,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
   name     = "tf-test"
-  image    = "${docker_image.foo.latest}"
+  image    = docker_image.foo.latest
   command  = ["/bin/sh", "-c", "for i in $(seq 1 10); do echo \"$i\"; done"]
   attach   = true
   logs     = true
@@ -2369,7 +2369,7 @@ keep_locally = true
 }
  resource "docker_container" "foo" {
 name = "tf-test"
-image = "${docker_image.foo.latest}"
+image = docker_image.foo.latest
 command = ["/bin/sh", "-c", "exit 123"]
 attach = true
 must_run = false
@@ -2383,7 +2383,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	sysctls = {
 		"net.ipv4.ip_forward" = "1"
@@ -2398,7 +2398,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	group_add = [
 		"users"
@@ -2413,7 +2413,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	group_add = [
 		100
@@ -2428,7 +2428,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 
 	group_add = [
 		1,
@@ -2445,7 +2445,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 	tty = true
 }
 `
@@ -2457,7 +2457,7 @@ resource "docker_image" "foo" {
 
 resource "docker_container" "foo" {
 	name = "tf-test"
-	image = "${docker_image.foo.latest}"
+	image = docker_image.foo.latest
 	stdin_open = true
 }
 `

--- a/docker/resource_docker_image_test.go
+++ b/docker/resource_docker_image_test.go
@@ -275,8 +275,8 @@ data "docker_registry_image" "foobarbaz" {
 	name = "alpine:3.1"
 }
 resource "docker_image" "foobarbaz" {
-	name = "${data.docker_registry_image.foobarbaz.name}"
-	pull_triggers = ["${data.docker_registry_image.foobarbaz.sha256_digest}"]
+	name = data.docker_registry_image.foobarbaz.name
+	pull_triggers = [data.docker_registry_image.foobarbaz.sha256_digest]
 }
 `
 
@@ -285,8 +285,8 @@ data "docker_registry_image" "foobarbazoo" {
 	name = "alpine:3.1"
 }
 resource "docker_image" "foobarbazoo" {
-	name = "${data.docker_registry_image.foobarbazoo.name}"
-	pull_trigger = "${data.docker_registry_image.foobarbazoo.sha256_digest}"
+	name = data.docker_registry_image.foobarbazoo.name
+	pull_trigger = data.docker_registry_image.foobarbazoo.sha256_digest
 }
 `
 
@@ -303,9 +303,9 @@ data "docker_registry_image" "foo_private" {
 }
 resource "docker_image" "foo_private" {
 	provider = "docker.private"
-	name = "${data.docker_registry_image.foo_private.name}"
+	name = data.docker_registry_image.foo_private.name
 	keep_locally = true
-	pull_triggers = ["${data.docker_registry_image.foo_private.sha256_digest}"]
+	pull_triggers = [data.docker_registry_image.foo_private.sha256_digest]
 }
 `
 
@@ -328,7 +328,7 @@ provider "docker" {
 	alias = "private"
 	registry_auth {
 		address = "%s"
-		config_file_content = "${file("%s")}"
+		config_file_content = file("%s")
 	}
 }
 resource "docker_image" "foo_private" {

--- a/docker/resource_docker_service_test.go
+++ b/docker/resource_docker_service_test.go
@@ -262,7 +262,7 @@ func TestAccDockerService_fullSpec(t *testing.T) {
 
 							mounts {
 								target      = "/mount/test"
-								source      = "${docker_volume.test_volume.name}"
+								source      = docker_volume.test_volume.name
 								type        = "volume"
 								read_only   = true
 
@@ -301,8 +301,8 @@ func TestAccDockerService_fullSpec(t *testing.T) {
 							}
 
 							secrets {
-								secret_id   = "${docker_secret.service_secret.id}"
-								secret_name = "${docker_secret.service_secret.name}"
+								secret_id   = docker_secret.service_secret.id
+								secret_name = docker_secret.service_secret.name
 								file_name   = "/secrets.json"
 								file_uid    = "0"
 								file_gid    = "0"
@@ -310,8 +310,8 @@ func TestAccDockerService_fullSpec(t *testing.T) {
 							}
 
 							configs {
-								config_id   = "${docker_config.service_config.id}"
-								config_name = "${docker_config.service_config.name}"
+								config_id   = docker_config.service_config.id
+								config_name = docker_config.service_config.name
 								file_name = "/configs.json"
 							}
 						}
@@ -349,7 +349,7 @@ func TestAccDockerService_fullSpec(t *testing.T) {
 
 						force_update = 0
 						runtime      = "container"
-						networks     = ["${docker_network.test_network.id}"]
+						networks     = [docker_network.test_network.id]
 
 						log_driver {
 							name = "json-file"
@@ -747,7 +747,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 	image := "127.0.0.1:15000/tftest-service:v1"
 	mounts := `
 	mounts {
-		source = "${docker_volume.foo.name}"
+		source = docker_volume.foo.name
 		target = "/mount/test"
 		type   = "volume"
 		read_only = true
@@ -794,7 +794,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 	healthcheckInterval2 := "2s"
 	mounts2 := `
 	mounts {
-		source = "${docker_volume.foo.name}"
+		source = docker_volume.foo.name
 		target = "/mount/test"
 		type   = "volume"
 		read_only = true
@@ -810,7 +810,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 		}
 	}
 	mounts {
-		source = "${docker_volume.foo2.name}"
+		source = docker_volume.foo2.name
 		target = "/mount/test2"
 		type   = "volume"
 		read_only = true
@@ -1230,14 +1230,14 @@ resource "docker_service" "foo" {
 			%s
 
 			configs {
-				config_id   = "${docker_config.service_config.id}"
-				config_name = "${docker_config.service_config.name}"
+				config_id   = docker_config.service_config.id
+				config_name = docker_config.service_config.name
 				file_name   = "/configs.json"
 			}
 
 			secrets {
-				secret_id   = "${docker_secret.service_secret.id}"
-				secret_name = "${docker_secret.service_secret.name}"
+				secret_id   = docker_secret.service_secret.id
+				secret_name = docker_secret.service_secret.name
 				file_name   = "/secrets.json"
 			}
 

--- a/website/docs/d/registry_image.html.markdown
+++ b/website/docs/d/registry_image.html.markdown
@@ -20,8 +20,8 @@ data "docker_registry_image" "ubuntu" {
 }
 
 resource "docker_image" "ubuntu" {
-  name          = "${data.docker_registry_image.ubuntu.name}"
-  pull_triggers = ["${data.docker_registry_image.ubuntu.sha256_digest}"]
+  name          = data.docker_registry_image.ubuntu.name
+  pull_triggers = [data.docker_registry_image.ubuntu.sha256_digest]
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -26,7 +26,7 @@ provider "docker" {
 
 # Create a container
 resource "docker_container" "foo" {
-  image = "${docker_image.ubuntu.latest}"
+  image = docker_image.ubuntu.latest
   name  = "foo"
 }
 
@@ -59,12 +59,12 @@ provider "docker" {
 
   registry_auth {
     address = "registry.hub.docker.com"
-    config_file = "${pathexpand("~/.docker/config.json")}"
+    config_file = pathexpand("~/.docker/config.json")
   }
 
   registry_auth {
     address = "registry.my.company.com"
-    config_file_content = "${var.plain_content_of_config_file}"
+    config_file_content = var.plain_content_of_config_file
   }
 
   registry_auth {
@@ -116,12 +116,12 @@ provider "docker" {
   host = "tcp://your-host-ip:2376/"
 
   # -> specify either
-  cert_path = "${pathexpand("~/.docker")}"
+  cert_path = pathexpand("~/.docker")
 
   # -> or the following
-  ca_material   = "${file(pathexpand("~/.docker/ca.pem"))}" # this can be omitted
-  cert_material = "${file(pathexpand("~/.docker/cert.pem"))}"
-  key_material  = "${file(pathexpand("~/.docker/key.pem"))}"
+  ca_material   = file(pathexpand("~/.docker/ca.pem")) # this can be omitted
+  cert_material = file(pathexpand("~/.docker/cert.pem"))
+  key_material  = file(pathexpand("~/.docker/key.pem"))
 }
 ```
 

--- a/website/docs/r/config.html.markdown
+++ b/website/docs/r/config.html.markdown
@@ -43,17 +43,17 @@ File `main.tf`
 ```hcl
 # Creates the template in renders the variable
 data "template_file" "foo_config_tpl" {
-  template = "${file("foo.config.json.tpl")}"
+  template = file("foo.config.json.tpl")
 
   vars {
-    port = "${var.foo_port}"
+    port = var.foo_port
   }
 }
 
 # Creates the config
 resource "docker_config" "foo_config" {
   name = "foo_config"
-  data = "${base64encode(data.template_file.foo_config_tpl.rendered)}"
+  data = base64encode(data.template_file.foo_config_tpl.rendered)
 }
 ```
 
@@ -65,7 +65,7 @@ in the example below. The reason is [moby-35803](https://github.com/moby/moby/is
 ```hcl
 resource "docker_config" "service_config" {
   name = "${var.service_name}-config-${replace(timestamp(), ":", ".")}"
-  data = "${base64encode(data.template_file.service_config_tpl.rendered)}"
+  data = base64encode(data.template_file.service_config_tpl.rendered)
 
   lifecycle {
     ignore_changes        = ["name"]
@@ -77,8 +77,8 @@ resource "docker_service" "service" {
   # ...
   configs = [
     {
-      config_id   = "${docker_config.service_config.id}"
-      config_name = "${docker_config.service_config.name}"
+      config_id   = docker_config.service_config.id
+      config_name = docker_config.service_config.name
       file_name   = "/root/configs/configs.json"
     },
   ]

--- a/website/docs/r/container.html.markdown
+++ b/website/docs/r/container.html.markdown
@@ -16,7 +16,7 @@ Manages the lifecycle of a Docker container.
 # Start a container
 resource "docker_container" "ubuntu" {
   name  = "foo"
-  image = "${docker_image.ubuntu.latest}"
+  image = docker_image.ubuntu.latest
 }
 
 # Find the latest Ubuntu precise image.
@@ -140,7 +140,7 @@ Example:
 ```hcl
 resource "docker_container" "ubuntu" {
   name  = "foo"
-  image = "${docker_image.ubuntu.latest}"
+  image = docker_image.ubuntu.latest
 
   capabilities {
     add  = ["ALL"]

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -34,8 +34,8 @@ data "docker_registry_image" "ubuntu" {
 }
 
 resource "docker_image" "ubuntu" {
-  name          = "${data.docker_registry_image.ubuntu.name}"
-  pull_triggers = ["${data.docker_registry_image.ubuntu.sha256_digest}"]
+  name          = data.docker_registry_image.ubuntu.name
+  pull_triggers = [data.docker_registry_image.ubuntu.sha256_digest]
 }
 ```
 

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -30,7 +30,7 @@ in the example below. The reason is [moby-35803](https://github.com/moby/moby/is
 ```hcl
 resource "docker_secret" "service_secret" {
   name = "${var.service_name}-secret-${replace(timestamp(), ":", ".")}"
-  data = "${base64encode(data.template_file.service_secret_tpl.rendered)}"
+  data = base64encode(data.template_file.service_secret_tpl.rendered)
 
   lifecycle {
     ignore_changes        = ["name"]
@@ -42,8 +42,8 @@ resource "docker_service" "service" {
   # ...
   secrets = [
     {
-      secret_id   = "${docker_secret.service_secret.id}"
-      secret_name = "${docker_secret.service_secret.name}"
+      secret_id   = docker_secret.service_secret.id
+      secret_name = docker_secret.service_secret.name
       file_name   = "/root/configs/configs.json"
     },
   ]

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -110,7 +110,7 @@ resource "docker_service" "foo" {
 
       mounts {
         target    = "/mount/test"
-        source    = "${docker_volume.test_volume.name}"
+        source    = docker_volume.test_volume.name
         type      = "volume"
         read_only = true
 
@@ -145,8 +145,8 @@ resource "docker_service" "foo" {
       }
 
       secrets {
-        secret_id   = "${docker_secret.service_secret.id}"
-        secret_name = "${docker_secret.service_secret.name}"
+        secret_id   = docker_secret.service_secret.id
+        secret_name = docker_secret.service_secret.name
         file_name   = "/secrets.json"
         file_uid    = "0"
         file_gid    = "0"
@@ -158,8 +158,8 @@ resource "docker_service" "foo" {
       }
 
       configs {
-        config_id   = "${docker_config.service_config.id}"
-        config_name = "${docker_config.service_config.name}"
+        config_id   = docker_config.service_config.id
+        config_name = docker_config.service_config.name
         file_name   = "/configs.json"
       }
 
@@ -221,7 +221,7 @@ resource "docker_service" "foo" {
 
     force_update = 0
     runtime      = "container"
-    networks     = ["${docker_network.test_network.id}"]
+    networks     = [docker_network.test_network.id]
 
     log_driver {
       name = "json-file"


### PR DESCRIPTION
> Warning: Interpolation-only expressions are deprecated
>
> Terraform 0.11 and earlier required all non-constant expressions to be
> provided via interpolation syntax, but this pattern is now deprecated. To
> silence this warning, remove the "${ sequence from the start and the }"
> sequence from the end of this expression, leaving just the inner expression.
>
> Template interpolation syntax is still used to construct strings from
> expressions when the template includes multiple interpolation sequences or a
> mixture of literal strings and interpolations. This deprecation applies only
> to templates that consist entirely of a single interpolation sequence.

We requires `Terraform >=0.12.x`, so we should fix legacy configuraiton style.

https://github.com/kreuzwerker/terraform-provider-docker#requirements