### PR TITLE
chore: add the guide about Terraform Configuration in Bug Report

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -44,6 +44,12 @@ If you are running into one of these scenarios, we recommend opening an issue in
 # Copy-paste your Terraform configurations here - for large Terraform configs,
 # please use a service like Dropbox and share a link to the ZIP file. For
 # security, you can also encrypt the files using our GPG public key: https://keybase.io/hashicorp
+# The code should be runnable for maintainers to reproduce the problem.
+# We can't reproduce the problem with partial code.
+# Don't include unknown input variables, local values, resources, etc.
+# If you can reproduce the problem with public Docker images, please don't use private Docker images.
+# Don't include unneeded resources to reproduce the problem.
+# Don't set unneeded attributes to reproduce the problem.
 ```
 
 ### Debug Output


### PR DESCRIPTION
## Motivation

Sometimes there are bug reports which we can't reproduce the problem.
By adding the guide to write good bug report, we want to solve this problem.
