### PR TITLE
fix: search local images with Docker image ID

### DIFF
--- a/internal/provider/resource_docker_image_test.go
+++ b/internal/provider/resource_docker_image_test.go
@@ -241,6 +241,25 @@ func testAccDockerImageDestroy(ctx context.Context, s *terraform.State) error {
 	return nil
 }
 
+func TestAccDockerImage_tag_sha265(t *testing.T) {
+	ctx := context.Background()
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccDockerImageDestroy(ctx, state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testDockerImageWithTagAndSHA256RepoDigest,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("docker_image.nginx", "latest", contentDigestRegexp),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDockerImage_build(t *testing.T) {
 	ctx := context.Background()
 	wd, _ := os.Getwd()
@@ -393,4 +412,10 @@ ARG test_arg
 RUN echo ${test_arg} > test_arg.txt
 
 RUN apt-get update -qq
+`
+
+const testDockerImageWithTagAndSHA256RepoDigest = `
+resource "docker_image" "nginx" {
+	name = "nginx:1.18.0-alpine@sha256:0c56c40f232f41c1b8341c3cc055c8b528cb6decefd7f7c8506e2d30bb9678b6"
+}
 `


### PR DESCRIPTION
https://github.com/kreuzwerker/terraform-provider-docker/issues/52#issuecomment-806581094 

## Problem to solve

9efd1265f0823289c65e7633f02996b01034d8c1
https://github.com/kreuzwerker/terraform-provider-docker/pull/151/checks?check_run_id=2197760165#step:16:537

```
=== RUN   TestAccDockerImage_tag_sha265
    resource_docker_image_test.go:246: Step 1/1 error: Error running apply: exit status 1
        2021/03/25 23:30:38 [DEBUG] Using modified User-Agent: Terraform/0.12.30 HashiCorp-terraform-exec/0.13.0
        
        Error: Unable to read Docker image into resource: Unable to find or pull image nginx:1.18.0-alpine@sha256:0c56c40f232f41c1b8341c3cc055c8b528cb6decefd7f7c8506e2d30bb9678b6
        
          on terraform_plugin_test.tf line 2, in resource "docker_image" "nginx":
           2: resource "docker_image" "nginx" {
        
        
--- FAIL: TestAccDockerImage_tag_sha265 (3.01s)
```

## How to solve

Search local images with Docker image ID.
We have to normalize the key which is used to search local images.