### PR TITLE
chore(renovate): update dependencies automatically by Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,19 @@
+{
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "postUpdateOptions": ["gomodTidy"],
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
+      "automerge": true,
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false,
+    }
+  ]
+}


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/

To use Renovate, we have to install GitHub App. https://github.com/apps/renovate

## Why not Dependabot?

https://dependabot.com/

I don't have a strong opinion, but I usually use Renovate for both personal OSS and job.
I'm not familiar with Dependabot.