### PR TITLE
fix/workflows

### DIFF
--- a/.github/workflows/acc-test.yaml
+++ b/.github/workflows/acc-test.yaml
@@ -9,7 +9,7 @@ on:
     types: ['opened', 'synchronize']
     paths:
       - '**.go'
-      - 'vendor/**'
+      - go.mod
       - '.github/workflows/**'
 
 env:

--- a/.github/workflows/acc-test.yaml
+++ b/.github/workflows/acc-test.yaml
@@ -15,6 +15,7 @@ on:
 env:
   GOPROXY: https://gocenter.io,https://proxy.golang.org,direct
   DEBIAN_FRONTEND: noninteractive
+  DOCKER_CE_VERSION: "5:20.10.1~3-0~ubuntu-focal"
 
 jobs:
   acc-test:
@@ -40,7 +41,7 @@ jobs:
       - run: sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
       - run: sudo apt-get update
       # list available docker versions: apt-cache policy docker-ce 
-      - run: sudo apt-get -y install docker-ce=5:20.10.1~3-0~ubuntu-focal
+      - run: sudo apt-get -y install docker-ce=${DOCKER_CE_VERSION}
       - run: docker version
       # Allow local registry to be insecure
       - run: sudo sed 's/DOCKER_OPTS="/DOCKER_OPTS="--insecure-registry=127.0.0.1:15000 /g' -i /etc/default/docker

--- a/.github/workflows/acc-test.yaml
+++ b/.github/workflows/acc-test.yaml
@@ -13,7 +13,6 @@ on:
       - '.github/workflows/**'
 
 env:
-  GO_VERSION: "1.16"
   GOPROXY: https://gocenter.io,https://proxy.golang.org,direct
   DEBIAN_FRONTEND: noninteractive
 

--- a/.github/workflows/acc-test.yaml
+++ b/.github/workflows/acc-test.yaml
@@ -1,4 +1,3 @@
----
 name: Acc Tests
 on:
   push:

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -13,7 +13,6 @@ on:
       - '.github/workflows/**'
 
 env:
-  GO_VERSION: "1.16"
   GOPROXY: https://gocenter.io,https://proxy.golang.org,direct
 
 jobs:

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -9,7 +9,7 @@ on:
     types: ['opened', 'synchronize']
     paths:
       - '**.go'
-      - 'vendor/**'
+      - go.mod
       - '.github/workflows/**'
 
 env:

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,4 +1,3 @@
----
 name: Compile Binaries
 on:
   push:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,4 +1,3 @@
----
 name: golangci-lint
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: '1.16'
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -13,7 +13,6 @@ on:
       - '.github/workflows/**'
 
 env:
-  GO_VERSION: "1.16"
   GOPROXY: https://gocenter.io,https://proxy.golang.org,direct
 
 jobs:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,4 +1,3 @@
----
 name: Unit Tests
 on:
   push:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -9,7 +9,7 @@ on:
     types: ['opened', 'synchronize']
     paths:
       - '**.go'
-      - 'vendor/**'
+      - go.mod
       - '.github/workflows/**'
 
 env:

--- a/.github/workflows/website-lint.yaml
+++ b/.github/workflows/website-lint.yaml
@@ -14,6 +14,7 @@ on:
 env:
   GO_VERSION: "1.16"
   GOPROXY: https://gocenter.io,https://proxy.golang.org,direct
+  DOCKER_CE_VERSION: "5:20.10.1~3-0~ubuntu-focal"
 
 jobs:
   website-lint-spellcheck-tffmt:
@@ -32,7 +33,7 @@ jobs:
       - run: sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
       - run: sudo apt-get update
       # list available docker versions: apt-cache policy docker-ce 
-      - run: sudo apt-get -y install docker-ce=5:20.10.1~3-0~ubuntu-focal
+      - run: sudo apt-get -y install docker-ce=${DOCKER_CE_VERSION}
       - run: docker version
       - run: make setup
       - run: make website-lint

--- a/.github/workflows/website-lint.yaml
+++ b/.github/workflows/website-lint.yaml
@@ -1,4 +1,3 @@
----
 name: Docs and Website Lint
 on:
   push:


### PR DESCRIPTION
- removed path for `vendor` directory, because we do not use and added `go.mod` path instead to trigger tests for renovate bot updates 
- aligned workflows
- removed duplicate declarations