### PR TITLE
feat: add pull_image setting to `docker_registry_image` datasource

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing
 
-By participating to this project, you agree to abide our [code of conduct](/CODE_OF_CONDUCT.md).
+By participating in this project, you agree to abide our [code of conduct](/CODE_OF_CONDUCT.md).
 
 ## Write Issue
 
 When you have a bug report or feature request or something, please create an issue from [here](https://github.com/kreuzwerker/terraform-provider-docker/issues/new/choose).
-Before creating an issue, please check whether same or releated issues exist.
+Before creating an issue, please check whether same or related issues exist.
 Please use issue templates as much as possible.
 
 ### Guide of Bug report
@@ -68,7 +68,7 @@ TF_LOG=INFO TF_ACC=1 go test -v ./internal/provider -run ^TestAccDockerImage_dat
 make testacc_cleanup
 ```
 
-Furthermore, we recommened running the linters for the code and the documentation:
+Furthermore, we recommend running the linters for the code and the documentation:
 
 ```sh
 # install all the dependencies

--- a/website/docs/d/registry_image.html.markdown
+++ b/website/docs/d/registry_image.html.markdown
@@ -16,7 +16,8 @@ to date on the latest available version of the tag.
 
 ```hcl
 data "docker_registry_image" "ubuntu" {
-  name = "ubuntu:precise"
+  name       = "ubuntu:precise"
+  pull_image = true
 }
 
 resource "docker_image" "ubuntu" {
@@ -30,6 +31,7 @@ resource "docker_image" "ubuntu" {
 The following arguments are supported:
 
 * `name` - (Required, string) The name of the Docker image, including any tags. e.g. `alpine:latest`
+* `pull_image` - (Optional, bool) Whether the image should be pulled when `sha256_digest` changed
 
 ## Attributes Reference
 


### PR DESCRIPTION
Resolves #172 

Going by my suggestion I tried skipping the local image check.
I didn't know if it's possible to check if the _sha256_digest_ referenced by pull_triggers changed...

So I ended up adding a new setting "pull_image" to the `docker_registry_image` datasource which is _false_ per default. If enabled, it will pull the image if the _sha256_digest_ was modified during the read.

I can't assess whether this change affects other resources as well. Also I wasn't sure how to test that properly.
Please tell me what you think about this change. :+1: 