### PR TITLE
Update the restart_policy documentation

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -237,7 +237,7 @@ resource "docker_service" "foo" {
       }
     }
 
-    restart_policy = {
+    restart_policy {
       condition    = "on-failure"
       delay        = "3s"
       max_attempts = 4


### PR DESCRIPTION
The restart_policy section, beginning on line 240, within the service documentation has an equals sign, identifying it as an argument, not a block.  Removing the "=" from the restart_policy line.

From...
...
240 restart_policy = {
...

To...
...
240 restart_policy {
...