### PR TITLE
feat: add parameter for SSH options

### DIFF
--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -21,6 +21,7 @@ import (
 // Docker API compatible host.
 type Config struct {
 	Host     string
+	SSHOpts  string
 	Ca       string
 	Cert     string
 	Key      string
@@ -118,7 +119,8 @@ func (c *Config) NewClient() (*client.Client, error) {
 	}
 
 	// If there is no cert information, then check for ssh://
-	helper, err := connhelper.GetConnectionHelper(c.Host)
+	ssh_opts_fields := strings.Fields(c.SSHOpts)
+	helper, err := connhelper.GetConnectionHelperWithSSHOpts(c.Host, ssh_opts_fields)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,7 +43,12 @@ func New(version string) func() *schema.Provider {
 					DefaultFunc: schema.EnvDefaultFunc("DOCKER_HOST", "unix:///var/run/docker.sock"),
 					Description: "The Docker daemon address",
 				},
-
+				"ssh_opts": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("DOCKER_SSH_OPTS", ""),
+					Description: "Addtional SSH option flags to be appended when using ssh:// protocol",
+				},
 				"ca_material": {
 					Type:        schema.TypeString,
 					Optional:    true,
@@ -148,6 +153,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		config := Config{
 			Host:     d.Get("host").(string),
+			SSHOpts:  d.Get("ssh_opts").(string),
 			Ca:       d.Get("ca_material").(string),
 			Cert:     d.Get("cert_material").(string),
 			Key:      d.Get("key_material").(string),


### PR DESCRIPTION
Allow setting arbitrary SSH option flags like `-i ~/.ssh/id_rsa` for private keys from files or `-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null` to ignore unknown host keys.

Related: #29 