### PR TITLE
docs: fix r/registry_image truncated docs

### DIFF
--- a/docs/resources/registry_image.md
+++ b/docs/resources/registry_image.md
@@ -51,7 +51,7 @@ Optional:
 
 - **auth_config** (Block List) The configuration for the authentication (see [below for nested schema](#nestedblock--build--auth_config))
 - **build_args** (Map of String) Pairs for build-time variables in the form TODO
-- **build_id** (String) BuildID is an optional identifier that can be passed together with the build request. The
+- **build_id** (String) BuildID is an optional identifier that can be passed together with the build request. The same identifier can be used to gracefully cancel the build with the cancel request.
 - **cache_from** (List of String) Images to consider as cache sources
 - **cgroup_parent** (String) Optional parent cgroup for the container
 - **cpu_period** (Number) The length of a CPU period in microseconds

--- a/internal/provider/resource_docker_registry_image.go
+++ b/internal/provider/resource_docker_registry_image.go
@@ -324,7 +324,7 @@ func resourceDockerRegistryImage() *schema.Resource {
 						},
 						"build_id": {
 							Type:        schema.TypeString,
-							Description: "BuildID is an optional identifier that can be passed together with the build request. The ",
+							Description: "BuildID is an optional identifier that can be passed together with the build request. The same identifier can be used to gracefully cancel the build with the cancel request.",
 							Optional:    true,
 							ForceNew:    true,
 						},


### PR DESCRIPTION
Fixes #268

Doc was truncated during docs migration. This PR restores original line from https://github.com/kreuzwerker/terraform-provider-docker/blob/96a6a8dbee96b0b24946bda22e4fd612fe613cb4/website/docs/r/registry_image.html.markdown?plain=1#L71 

Happy Hacktoberfest!