### PR TITLE
docs: fix service options

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,7 @@ provider "docker" {
 - **host** (String) The Docker daemon address
 - **key_material** (String) PEM-encoded content of Docker client private key
 - **registry_auth** (Block List, Max: 1) (see [below for nested schema](#nestedblock--registry_auth))
+- **ssh_opts** (List of String) Addtional SSH option flags to be appended when using `ssh://` protocol
 
 <a id="nestedblock--registry_auth"></a>
 ### Nested Schema for `registry_auth`

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,7 +166,7 @@ provider "docker" {
 - **host** (String) The Docker daemon address
 - **key_material** (String) PEM-encoded content of Docker client private key
 - **registry_auth** (Block List, Max: 1) (see [below for nested schema](#nestedblock--registry_auth))
-- **ssh_opts** (List of String) Addtional SSH option flags to be appended when using `ssh://` protocol
+- **ssh_opts** (List of String) Additional SSH option flags to be appended when using `ssh://` protocol
 
 <a id="nestedblock--registry_auth"></a>
 ### Nested Schema for `registry_auth`

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -263,7 +263,7 @@ resource "docker_service" "foo" {
     log_driver {
       name = "json-file"
 
-      options {
+      options = {
         max-size = "10m"
         max-file = "3"
       }
@@ -361,7 +361,7 @@ Optional:
 - **command** (List of String) The command/entrypoint to be run in the image. According to the [docker cli](https://github.com/docker/cli/blob/v20.10.7/cli/command/service/opts.go#L705) the override of the entrypoint is also passed to the `command` property and there is no `entrypoint` attribute in the `ContainerSpec` of the service.
 - **configs** (Block Set) References to zero or more configs that will be exposed to the service (see [below for nested schema](#nestedblock--task_spec--container_spec--configs))
 - **dir** (String) The working directory for commands to run in
-- **dns_config** (Block List, Max: 1) Specification for DNS related configurations in resolver configuration file (resolv.conf) (see [below for nested schema](#nestedblock--task_spec--container_spec--dns_config))
+- **dns_config** (Block List, Max: 1) Specification for DNS related configurations in resolver configuration file (`resolv.conf`) (see [below for nested schema](#nestedblock--task_spec--container_spec--dns_config))
 - **env** (Map of String) A list of environment variables in the form VAR="value"
 - **groups** (List of String) A list of additional groups that the container process will run as
 - **healthcheck** (Block List, Max: 1) A test to perform to check that the container is healthy (see [below for nested schema](#nestedblock--task_spec--container_spec--healthcheck))
@@ -402,7 +402,7 @@ Required:
 
 Optional:
 
-- **options** (List of String) A list of internal resolver variables to be modified (e.g., debug, ndots:3, etc.)
+- **options** (List of String) A list of internal resolver variables to be modified (e.g., `debug`, `ndots:3`, etc.)
 - **search** (List of String) A search list for host-name lookup
 
 
@@ -560,7 +560,7 @@ Optional:
 - **constraints** (Set of String) An array of constraints. e.g.: `node.role==manager`
 - **max_replicas** (Number) Maximum number of replicas for per node (default value is `0`, which is unlimited)
 - **platforms** (Block Set) Platforms stores all the platforms that the service's image can run on (see [below for nested schema](#nestedblock--task_spec--placement--platforms))
-- **prefs** (Set of String) Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence, e.g.: spread=node.role.manager
+- **prefs** (Set of String) Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence, e.g.: `spread=node.role.manager`
 
 <a id="nestedblock--task_spec--placement--platforms"></a>
 ### Nested Schema for `task_spec.placement.platforms`
@@ -586,7 +586,7 @@ Optional:
 Optional:
 
 - **memory_bytes** (Number) The amounf of memory in bytes the container allocates
-- **nano_cpus** (Number) CPU shares in units of `1/1e9` (or `10^-9`) of the CPU. Should be at least 1000000
+- **nano_cpus** (Number) CPU shares in units of `1/1e9` (or `10^-9`) of the CPU. Should be at least `1000000`
 
 
 <a id="nestedblock--task_spec--resources--reservation"></a>
@@ -596,7 +596,7 @@ Optional:
 
 - **generic_resources** (Block List, Max: 1) User-defined resources can be either Integer resources (e.g, `SSD=3`) or String resources (e.g, GPU=UUID1) (see [below for nested schema](#nestedblock--task_spec--resources--reservation--generic_resources))
 - **memory_bytes** (Number) The amounf of memory in bytes the container allocates
-- **nano_cpus** (Number) CPU shares in units of 1/1e9 (or 10^-9) of the CPU. Should be at least 1000000
+- **nano_cpus** (Number) CPU shares in units of 1/1e9 (or 10^-9) of the CPU. Should be at least `1000000`
 
 <a id="nestedblock--task_spec--resources--reservation--generic_resources"></a>
 ### Nested Schema for `task_spec.resources.reservation.nano_cpus`
@@ -639,8 +639,8 @@ Optional:
 
 Optional:
 
-- **delay** (String) The interval to check if the desired state is reached (ms|s). Defaults to `7s`.
-- **timeout** (String) The timeout of the service to reach the desired state (s|m). Defaults to `3m`
+- **delay** (String) The interval to check if the desired state is reached `(ms|s)`. Defaults to `7s`.
+- **timeout** (String) The timeout of the service to reach the desired state `(s|m)`. Defaults to `3m`
 
 
 <a id="nestedblock--endpoint_spec"></a>
@@ -661,7 +661,7 @@ Required:
 Optional:
 
 - **name** (String) A random name for the port
-- **protocol** (String) Rrepresents the protocol of a port: 'tcp', 'udp' or 'sctp'. Defaults to `tcp`.
+- **protocol** (String) Rrepresents the protocol of a port: `tcp`, `udp` or `sctp`. Defaults to `tcp`.
 - **publish_mode** (String) Represents the mode in which the port is to be published: 'ingress' or 'host'. Defaults to `ingress`.
 - **published_port** (Number) The port on the swarm hosts
 
@@ -711,8 +711,8 @@ Optional:
 
 Optional:
 
-- **delay** (String) Delay between task updates (ns|us|ms|s|m|h). Defaults to `0s`.
-- **failure_action** (String) Action on update failure: pause | continue | rollback. Defaults to `pause`.
+- **delay** (String) Delay between task updates `(ns|us|ms|s|m|h)`. Defaults to `0s`.
+- **failure_action** (String) Action on update failure: `pause`, `continue` or `rollback`. Defaults to `pause`.
 - **max_failure_ratio** (String) Failure rate to tolerate during an update. Defaults to `0.0`.
 - **monitor** (String) Duration after each task update to monitor for failure (ns|us|ms|s|m|h). Defaults to `5s`.
 - **order** (String) Update order: either 'stop-first' or 'start-first'. Defaults to `stop-first`.

--- a/examples/provider/provider-ssh.tf
+++ b/examples/provider/provider-ssh.tf
@@ -1,3 +1,4 @@
 provider "docker" {
-  host = "ssh://user@remote-host:22"
+  host     = "ssh://user@remote-host:22"
+  ssh_opts = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
 }

--- a/examples/resources/docker_service/resource-advanced.tf
+++ b/examples/resources/docker_service/resource-advanced.tf
@@ -180,7 +180,7 @@ resource "docker_service" "foo" {
     log_driver {
       name = "json-file"
 
-      options {
+      options = {
         max-size = "10m"
         max-file = "3"
       }

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,21 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.61.0 // indirect
+	cloud.google.com/go/storage v1.10.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3 // indirect
 	github.com/Microsoft/hcsshim v0.8.15 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg v1.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 // indirect
+	github.com/aws/aws-sdk-go v1.31.6 // indirect
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/containerd/cgroups v0.0.0-20200824123100-0b889c03f102 // indirect
 	github.com/containerd/containerd v1.5.0-beta.1 // indirect
 	github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e // indirect
@@ -30,12 +39,16 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-getter v1.5.3 // indirect
 	github.com/hashicorp/go-hclog v0.16.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.1 // indirect
+	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/hashicorp/hc-install v0.3.1 // indirect
@@ -43,14 +56,21 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.15.0 // indirect
 	github.com/hashicorp/terraform-json v0.13.0 // indirect
+	github.com/hashicorp/terraform-plugin-docs v0.5.1 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.5.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.2.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/jmespath/go-jmespath v0.3.0 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/klauspost/compress v1.11.3 // indirect
 	github.com/magefile/mage v1.10.0 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/cli v1.1.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
@@ -67,15 +87,24 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v1.0.0-rc93 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/posener/complete v1.1.1 // indirect
+	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/sirupsen/logrus v1.8.0 // indirect
+	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	go.opencensus.io v0.22.4 // indirect
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/api v0.29.0 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
 	google.golang.org/grpc v1.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,10 +105,13 @@ github.com/Djarvur/go-err113 v0.0.0-20200410182137-af658d038157/go.mod h1:4UJr5H
 github.com/Djarvur/go-err113 v0.1.0/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20191009163259-e802c2cb94ae/go.mod h1:mjwGPas4yKduTyubHvD1Atl9r1rUq8DfVy+gkVvZ+oo=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
+github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
@@ -174,6 +177,7 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
+github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -197,6 +201,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
+github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
@@ -559,6 +564,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.3.0/go.mod h1:i1DMg/Lu8Sz5yYl25iOdmc5CT5qusaa+zmRWs16741s=
 github.com/google/wire v0.4.0/go.mod h1:ngWDr9Qvq3yZA10YrxfyGELY/AFWGVpy9c1LTRi1EoU=
@@ -667,6 +673,8 @@ github.com/hashicorp/terraform-exec v0.15.0 h1:cqjh4d8HYNQrDoEmlSGelHmg2DYDh5yay
 github.com/hashicorp/terraform-exec v0.15.0/go.mod h1:H4IG8ZxanU+NW0ZpDRNsvh9f0ul7C0nHP+rUR/CHs7I=
 github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniyEi5CM+FWGY=
 github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
+github.com/hashicorp/terraform-plugin-docs v0.5.1 h1:WwrUcamix9x0TqfTw/WGHMRqoTe1QPZKaeWJPuFb4lQ=
+github.com/hashicorp/terraform-plugin-docs v0.5.1/go.mod h1:SQwEgy0/B0UPQ07rNEG1Wpt6E3jvRcCwkVHPNybGgc0=
 github.com/hashicorp/terraform-plugin-go v0.5.0 h1:+gCDdF0hcYCm0YBTxrP4+K1NGIS5ZKZBKDORBewLJmg=
 github.com/hashicorp/terraform-plugin-go v0.5.0/go.mod h1:PAVN26PNGpkkmsvva1qfriae5Arky3xl3NfzKa8XFVM=
 github.com/hashicorp/terraform-plugin-log v0.2.0 h1:rjflRuBqCnSk3UHOR25MP1G5BDLKktTA6lNjjcAnBfI=
@@ -682,6 +690,7 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -806,6 +815,7 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/cli v1.1.2 h1:PvH+lL2B7IQ101xQL63Of8yFS2y+aDlsFcsqNc+u/Kw=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -940,6 +950,7 @@ github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdL
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posener/complete v1.1.1 h1:ccV59UEOTzVDnDUEFdT95ZzHVZ+5+158q8+SJb2QV5w=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -988,6 +999,8 @@ github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
+github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.0.4/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
 github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUccKSJBU0UMXJFVM=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,7 +54,7 @@ func New(version string) func() *schema.Provider {
 
 						return nil, nil
 					},
-					Description: "Addtional SSH option flags to be appended when using `ssh://` protocol",
+					Description: "Additional SSH option flags to be appended when using `ssh://` protocol",
 				},
 				"ca_material": {
 					Type:        schema.TypeString,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,7 +54,7 @@ func New(version string) func() *schema.Provider {
 
 						return nil, nil
 					},
-					Description: "Addtional SSH option flags to be appended when using ssh:// protocol",
+					Description: "Addtional SSH option flags to be appended when using `ssh://` protocol",
 				},
 				"ca_material": {
 					Type:        schema.TypeString,

--- a/internal/provider/resource_docker_service.go
+++ b/internal/provider/resource_docker_service.go
@@ -379,7 +379,7 @@ func resourceDockerService() *schema.Resource {
 									},
 									"dns_config": {
 										Type:        schema.TypeList,
-										Description: "Specification for DNS related configurations in resolver configuration file (resolv.conf)",
+										Description: "Specification for DNS related configurations in resolver configuration file (`resolv.conf`)",
 										MaxItems:    1,
 										Optional:    true,
 										Computed:    true,
@@ -399,7 +399,7 @@ func resourceDockerService() *schema.Resource {
 												},
 												"options": {
 													Type:        schema.TypeList,
-													Description: "A list of internal resolver variables to be modified (e.g., debug, ndots:3, etc.)",
+													Description: "A list of internal resolver variables to be modified (e.g., `debug`, `ndots:3`, etc.)",
 													Optional:    true,
 													Elem:        &schema.Schema{Type: schema.TypeString},
 												},
@@ -519,7 +519,7 @@ func resourceDockerService() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"nano_cpus": {
 													Type:        schema.TypeInt,
-													Description: "CPU shares in units of `1/1e9` (or `10^-9`) of the CPU. Should be at least 1000000",
+													Description: "CPU shares in units of `1/1e9` (or `10^-9`) of the CPU. Should be at least `1000000`",
 													Optional:    true,
 												},
 												"memory_bytes": {
@@ -538,7 +538,7 @@ func resourceDockerService() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"nano_cpus": {
-													Description: "CPU shares in units of 1/1e9 (or 10^-9) of the CPU. Should be at least 1000000",
+													Description: "CPU shares in units of 1/1e9 (or 10^-9) of the CPU. Should be at least `1000000`",
 													Type:        schema.TypeInt,
 													Optional:    true,
 												},
@@ -627,7 +627,7 @@ func resourceDockerService() *schema.Resource {
 									},
 									"prefs": {
 										Type:        schema.TypeSet,
-										Description: "Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence, e.g.: spread=node.role.manager",
+										Description: "Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence, e.g.: `spread=node.role.manager`",
 										Optional:    true,
 										Elem:        &schema.Schema{Type: schema.TypeString},
 										Set:         schema.HashString,
@@ -759,14 +759,14 @@ func resourceDockerService() *schema.Resource {
 						},
 						"delay": {
 							Type:             schema.TypeString,
-							Description:      "Delay between task updates (ns|us|ms|s|m|h). Defaults to `0s`.",
+							Description:      "Delay between task updates `(ns|us|ms|s|m|h)`. Defaults to `0s`.",
 							Default:          "0s",
 							Optional:         true,
 							ValidateDiagFunc: validateDurationGeq0(),
 						},
 						"failure_action": {
 							Type:             schema.TypeString,
-							Description:      "Action on update failure: pause | continue | rollback. Defaults to `pause`.",
+							Description:      "Action on update failure: `pause`, `continue` or `rollback`. Defaults to `pause`.",
 							Default:          "pause",
 							Optional:         true,
 							ValidateDiagFunc: validateStringMatchesPattern("^(pause|continue|rollback)$"),
@@ -875,7 +875,7 @@ func resourceDockerService() *schema.Resource {
 									},
 									"protocol": {
 										Type:             schema.TypeString,
-										Description:      "Rrepresents the protocol of a port: 'tcp', 'udp' or 'sctp'. Defaults to `tcp`.",
+										Description:      "Rrepresents the protocol of a port: `tcp`, `udp` or `sctp`. Defaults to `tcp`.",
 										Default:          "tcp",
 										Optional:         true,
 										ValidateDiagFunc: validateStringMatchesPattern(`^(tcp|udp|sctp)$`),
@@ -914,14 +914,14 @@ func resourceDockerService() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"delay": {
 							Type:             schema.TypeString,
-							Description:      "The interval to check if the desired state is reached (ms|s). Defaults to `7s`.",
+							Description:      "The interval to check if the desired state is reached `(ms|s)`. Defaults to `7s`.",
 							Default:          "7s",
 							Optional:         true,
 							ValidateDiagFunc: validateDurationGeq0(),
 						},
 						"timeout": {
 							Type:             schema.TypeString,
-							Description:      "The timeout of the service to reach the desired state (s|m). Defaults to `3m`",
+							Description:      "The timeout of the service to reach the desired state `(s|m)`. Defaults to `3m`",
 							Default:          "3m",
 							Optional:         true,
 							ValidateDiagFunc: validateDurationGeq0(),


### PR DESCRIPTION
and additionally
- fixes website docs of #335 
- beautifies the service docs
- replace markdown-cli image due to the [hint](https://gitlab.com/06kellyjac/docker_markdownlint-cli#how-to-use-this-image). Note: had to build it locally for my M1 and added a [PR](https://gitlab.com/06kellyjac/docker_markdownlint-cli/-/merge_requests/4)