### PR TITLE
fix(ci): Pipeline updates

### DIFF
--- a/.github/workflows/acc-test.yaml
+++ b/.github/workflows/acc-test.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   acc-test:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,5 +15,6 @@
       "matchUpdateTypes": ["digest"],
       "enabled": false,
     }
-  ]
+  ],
+  "ignorePaths": ["**/testdata/**"]
 }


### PR DESCRIPTION
This fixes two things:

- Increasing the timeout of the github actions to 15 min, as the last runs always timed out (https://github.com/kreuzwerker/terraform-provider-docker/actions/runs/2514887891)
- Adding `testdata` folder to renovate ignorePath, we don't need renovate PRs for the docker versions used there.