### PR TITLE
fix: Optimize tests and CI/CD by using smaller docker images

### DIFF
--- a/internal/provider/resource_docker_container_test.go
+++ b/internal/provider/resource_docker_container_test.go
@@ -958,7 +958,7 @@ func TestAccDockerContainer_multipleUploadContentsConfig(t *testing.T) {
 			{
 				Config: `
 				resource "docker_image" "foo" {
-					name         = "nginx:latest"
+					name         = "busybox:1.35.0"
 					keep_locally = true
 				}
 				
@@ -989,7 +989,7 @@ func TestAccDockerContainer_noUploadContentsConfig(t *testing.T) {
 			{
 				Config: `
 				resource "docker_image" "foo" {
-					name         = "nginx:latest"
+					name         = "busybox:1.35.0"
 					keep_locally = true
 				}
 				

--- a/testdata/resources/docker_container/testAccDockerContainer2NetworksConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainer2NetworksConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerCustomizedConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerCustomizedConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerDeviceConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerDeviceConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerGroupAddIdConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerGroupAddIdConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerGroupAddMultipleConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerGroupAddMultipleConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerGroupAddNameConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerGroupAddNameConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerHealthcheckConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerHealthcheckConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerInitConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerInitConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "fooinit" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "fooinit" {

--- a/testdata/resources/docker_container/testAccDockerContainerInternalPortConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerInternalPortConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerMountsConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerMountsConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo_mounts" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_volume" "foo_mounts" {

--- a/testdata/resources/docker_container/testAccDockerContainerMultipleInternalPortConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerMultipleInternalPortConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerMultiplePortConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerMultiplePortConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerNetworksDualStackAddressConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerNetworksDualStackAddressConfig.tf
@@ -11,7 +11,7 @@ resource "docker_network" "test" {
   }
 }
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerNetworksIPv4AddressConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerNetworksIPv4AddressConfig.tf
@@ -5,7 +5,7 @@ resource "docker_network" "test" {
   }
 }
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerNetworksIPv6AddressConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerNetworksIPv6AddressConfig.tf
@@ -7,7 +7,7 @@ resource "docker_network" "test" {
   }
 }
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerNoStartConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerNoStartConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerPortConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerPortConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerSTDIN_Config.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerSTDIN_Config.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerSysctlsConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerSysctlsConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerTTYConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerTTYConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerTmpfsConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerTmpfsConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerUpdateConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerUpdateConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerUploadBase64Config.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerUploadBase64Config.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerUploadConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerUploadConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerUploadSourceConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerUploadSourceConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerUploadSourceHashConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerUploadSourceHashConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name         = "nginx:latest"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }
 

--- a/testdata/resources/docker_container/testAccDockerContainerVolumeConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerVolumeConfig.tf
@@ -1,5 +1,5 @@
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_volume" "foo" {

--- a/testdata/resources/docker_container/testAccDockerContainerWith2BridgeNetworkConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerWith2BridgeNetworkConfig.tf
@@ -7,7 +7,7 @@ resource "docker_network" "tftest_2" {
 }
 
 resource "docker_image" "foo" {
-  name = "nginx:latest"
+  name = "busybox:1.35.0"
 }
 
 resource "docker_container" "foo" {

--- a/testdata/resources/docker_image/testAccDockerImageKeepLocallyConfig.tf
+++ b/testdata/resources/docker_image/testAccDockerImageKeepLocallyConfig.tf
@@ -1,4 +1,4 @@
 resource "docker_image" "foobarzoo" {
-  name         = "crux:3.1"
+  name         = "busybox:1.35.0"
   keep_locally = true
 }

--- a/testdata/resources/docker_image/testAccDockerImageWithTagAndSHA256RepoDigest.tf
+++ b/testdata/resources/docker_image/testAccDockerImageWithTagAndSHA256RepoDigest.tf
@@ -1,3 +1,3 @@
 resource "docker_image" "nginx" {
-  name = "nginx:1.21.4@sha256:097c3a0913d7e3a5b01b6c685a60c03632fc7a2b50bc8e35bcaa3691d788226e"
+  name = "busybox:1.35.0@sha256:8cde9b8065696b65d7b7ffaefbab0262d47a5a9852bfd849799559d296d2e0cd"
 }

--- a/testdata/resources/docker_image/testAddDockerImageWithSHA256RepoDigest.tf
+++ b/testdata/resources/docker_image/testAddDockerImageWithSHA256RepoDigest.tf
@@ -1,3 +1,3 @@
 resource "docker_image" "foobar" {
-  name = "stocard/gotthard@sha256:38c221641daa2035839da6aea7d0fbad4a1bef91f7ba1024ef953a747dc6108d"
+  name = "busybox@sha256:8cde9b8065696b65d7b7ffaefbab0262d47a5a9852bfd849799559d296d2e0cd"
 }


### PR DESCRIPTION
This PR unifies the image usage in (mostly) tests.

I noticed this, because I could not run some tests locally. The `crux` image is not maintained anymore since over 2 years, and thus, has no `arm64` image (I am running  an M1 mac).

In addition, the `busybox:1.35.0` is almost 60 MB smaller than the `nginx:latest`, so that will hopefully also account for some time reduction in CI/CD.

Things I noticed while debugging:

- Many tests implicit assume that the container keeps running. A simple `busybox` does not suffice, because it instantly exists. Then test fail, because they can't cleanup
- Tests with networking need an image which expose a port. Simple `busybox` does not work here, either