### PR TITLE
fix: compare relative paths when excluding, fixes kreuzwerker#280

### DIFF
--- a/internal/provider/resource_docker_registry_image_funcs.go
+++ b/internal/provider/resource_docker_registry_image_funcs.go
@@ -292,7 +292,7 @@ func buildDockerImageContextTar(buildContext string) (string, error) {
 
 	pm, err := fileutils.NewPatternMatcher(excludes)
 	if err != nil {
-		return "", fmt.Errorf("unable to create pattern matcher from .dockerignore exlcudes - %v", err.Error())
+		return "", fmt.Errorf("unable to create pattern matcher from .dockerignore excludes - %v", err.Error())
 	}
 
 	tw := tar.NewWriter(tmpFile)
@@ -305,7 +305,8 @@ func buildDockerImageContextTar(buildContext string) (string, error) {
 		}
 
 		// if .dockerignore is present, ignore files from there
-		skip, err := pm.Matches(file)
+		rel, _ := filepath.Rel(buildContext, file)
+		skip, err := pm.Matches(rel)
 		if err != nil {
 			return err
 		}

--- a/scripts/testing/docker_registry_image_context_dockerignore/.dockerignore
+++ b/scripts/testing/docker_registry_image_context_dockerignore/.dockerignore
@@ -1,1 +1,1 @@
-empty_to_ignore
+to_be_ignored

--- a/scripts/testing/docker_registry_image_context_dockerignore/Dockerfile
+++ b/scripts/testing/docker_registry_image_context_dockerignore/Dockerfile
@@ -1,2 +1,2 @@
 FROM scratch
-COPY empty /empty
+COPY * /

--- a/testdata/resources/docker_registry_image/testBuildDockerRegistryImageNoKeepJustCache.tf
+++ b/testdata/resources/docker_registry_image/testBuildDockerRegistryImageNoKeepJustCache.tf
@@ -1,0 +1,18 @@
+provider "docker" {
+  alias = "private"
+  registry_auth {
+    address = "%s"
+  }
+}
+resource "docker_registry_image" "%s" {
+  provider             = "docker.private"
+  name                 = "%s"
+  insecure_skip_verify = true
+
+  build {
+    context      = "%s"
+    remove       = false
+    force_remove = false
+    no_cache     = false
+  }
+}


### PR DESCRIPTION
Finally found time to write a test for the fix I proposed earlier in #280.

This fix itself is a trivial change from trying to match absolute paths to matching relative paths.

The bulk of changes are related to fixing the ignore file acceptance test which didn't really test anything at all due to a number of flaws (which this PR fixes):
- Dockerfile was not setup to COPY the ignored file so the test was not detecting that the ignore functionality did not work (the ignored file was added to the build context tar, but not to the image).
- The test looked like it wanted to compare the digest of an image before and after changing an ignored file. However it was only testing for the existence of an image digest.
- The test steps were using the same resource so terraform only actually built the image once.

The test now works properly which can be verified by changing the ignore file in which case the test will fail.
