### PR TITLE
fix: Enables having a Dockerfile outside the context

### DIFF
--- a/internal/provider/resource_docker_image_test.go
+++ b/internal/provider/resource_docker_image_test.go
@@ -324,6 +324,7 @@ RUN echo ${test_arg} > test_arg.txt
 RUN apt-get update -qq
 `
 
+// Test for implementation of https://github.com/kreuzwerker/terraform-provider-docker/issues/401
 func TestAccDockerImage_buildOutsideContext(t *testing.T) {
 	ctx := context.Background()
 	wd, _ := os.Getwd()

--- a/internal/provider/resource_docker_registry_image_test.go
+++ b/internal/provider/resource_docker_registry_image_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -243,6 +244,30 @@ func TestAccDockerRegistryImageResource_whitelistDockerignore(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, RESOURCE, "docker_registry_image", "testDockerRegistryImageFilePermissions"), pushOptions.Registry, pushOptions.Name, context, "Dockerfile"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("docker_registry_image.file_permissions", "sha256_digest"),
+				),
+			},
+		},
+	})
+}
+
+// Test for https://github.com/kreuzwerker/terraform-provider-docker/issues/249
+func TestAccDockerRegistryImageResource_DockerfileOutsideContext(t *testing.T) {
+	pushOptions := createPushImageOptions("127.0.0.1:15000/tftest-dockerregistryimage-dockerfileoutsidecontext:1.0")
+	wd, _ := os.Getwd()
+	dfPath := filepath.Join(wd, "..", "Dockerfile")
+	if err := ioutil.WriteFile(dfPath, []byte(testDockerFileExample), 0o644); err != nil {
+		t.Fatalf("failed to create a Dockerfile %s for test: %+v", dfPath, err)
+	}
+	defer os.Remove(dfPath)
+	context := strings.ReplaceAll((filepath.Join(wd, "..", "..", "scripts", "testing", "docker_registry_image_file_permissions")), "\\", "\\\\")
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(loadTestConfiguration(t, RESOURCE, "docker_registry_image", "testDockerRegistryImageDockerfileOutsideContext"), pushOptions.Registry, pushOptions.Name, context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("docker_registry_image.outside_context", "sha256_digest"),
 				),
 			},
 		},

--- a/testdata/resources/docker_image/testDockerImageDockerfileOutsideContext.tf
+++ b/testdata/resources/docker_image/testDockerImageDockerfileOutsideContext.tf
@@ -1,0 +1,9 @@
+resource "docker_image" "outside_context" {
+  name = "outside-context:latest"
+
+  build {
+    path = "."
+    dockerfile = "../Dockerfile"
+  }
+}
+

--- a/testdata/resources/docker_registry_image/testDockerRegistryImageDockerfileOutsideContext.tf
+++ b/testdata/resources/docker_registry_image/testDockerRegistryImageDockerfileOutsideContext.tf
@@ -1,0 +1,17 @@
+provider "docker" {
+  alias = "private"
+  registry_auth {
+    address = "%s"
+  }
+}
+
+resource "docker_registry_image" "outside_context" {
+  provider             = "docker.private"
+  name                 = "%s"
+  insecure_skip_verify = true
+
+  build {
+    context    = "%s"
+    dockerfile = "../Dockerfile"
+  }
+}


### PR DESCRIPTION
This aligns the implementation with the offical `docker build` command. Users are now able to specify `Dockerfiles` which are outside the build context.
Upstream file: https://github.com/docker/cli/blob/master/cli/command/image/build.go#L229

This shoud not break anything :)

Fixes #401 