### PR TITLE
Fix error handling in searchLoclImages()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+*~
+*.bak
+
+**/.envrc
+
 *.dll
 *.exe
 .DS_Store

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,7 +21,7 @@ golangci-lint:
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+		xargs -t -n4 go test $(TESTARGS) -timeout=40s -parallel=4
 
 testacc_setup: fmtcheck
 	@sh -c "'$(CURDIR)/scripts/testacc_setup.sh'"

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -44,7 +44,7 @@ func buildHTTPClientFromBytes(caPEMCert, certPEMBlock, keyPEMBlock []byte) (*htt
 	} else {
 		caPool := x509.NewCertPool()
 		if !caPool.AppendCertsFromPEM(caPEMCert) {
-			return nil, errors.New("Could not add RootCA pem")
+			return nil, errors.New("could not add RootCA pem")
 		}
 		tlsConfig.RootCAs = caPool
 	}

--- a/internal/provider/data_source_docker_image.go
+++ b/internal/provider/data_source_docker_image.go
@@ -44,9 +44,9 @@ func dataSourceDockerImageRead(ctx context.Context, d *schema.ResourceData, meta
 
 	imageName := d.Get("name").(string)
 
-	foundImage := searchLocalImages(ctx, client, data, imageName)
-	if foundImage == nil {
-		return diag.Errorf("did not find docker image '%s'", imageName)
+	foundImage, err := searchLocalImages(ctx, client, data, imageName)
+	if err != nil {
+		return diag.Errorf("error looking up local image %q: %s", imageName, err)
 	}
 
 	repoDigest := determineRepoDigest(imageName, foundImage)

--- a/internal/provider/resource_docker_container_funcs.go
+++ b/internal/provider/resource_docker_container_funcs.go
@@ -885,7 +885,7 @@ func resourceDockerContainerDelete(ctx context.Context, d *schema.ResourceData, 
 func fetchDockerContainer(ctx context.Context, ID string, client *client.Client) (*types.Container, error) {
 	apiContainers, err := client.ContainerList(ctx, types.ContainerListOptions{All: true})
 	if err != nil {
-		return nil, fmt.Errorf("error fetching container information from Docker: %s\n", err)
+		return nil, fmt.Errorf("error fetching container information from Docker: %s", err)
 	}
 
 	for _, apiContainer := range apiContainers {

--- a/internal/provider/resource_docker_service_structures.go
+++ b/internal/provider/resource_docker_service_structures.go
@@ -1083,17 +1083,14 @@ func createServiceNetworks(v interface{}) ([]swarm.NetworkAttachmentConfig, erro
 func createLogDriver(v interface{}) (*swarm.Driver, error) {
 	logDriver := swarm.Driver{}
 	if len(v.([]interface{})) > 0 {
-		for _, rawLogging := range v.([]interface{}) {
-			rawLogging := rawLogging.(map[string]interface{})
-			if rawName, ok := rawLogging["name"]; ok {
-				logDriver.Name = rawName.(string)
-			}
-			if rawOptions, ok := rawLogging["options"]; ok {
-				logDriver.Options = mapTypeMapValsToString(rawOptions.(map[string]interface{}))
-			}
-			// TODO SA4004: the surrounding loop is unconditionally terminated (staticcheck)
-			return &logDriver, nil //nolint:staticcheck
+		rawLogging := v.([]interface{})[0].(map[string]interface{})
+		if rawName, ok := rawLogging["name"]; ok {
+			logDriver.Name = rawName.(string)
 		}
+		if rawOptions, ok := rawLogging["options"]; ok {
+			logDriver.Options = mapTypeMapValsToString(rawOptions.(map[string]interface{}))
+		}
+		return &logDriver, nil //nolint:staticcheck
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Hopefully this improves our ability to debug the masked error and potentially racey behaviour in infra that relies on the Docker provider via Terraform mover SSH.

cc @Junkern 