### PR TITLE
fix: Throw errors when any part of docker config file handling goes wrong

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -260,15 +260,15 @@ func providerSetToRegistryAuth(authList []interface{}) (*AuthConfigs, error) {
 			}
 			r, err := os.Open(filePath)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("Could not open config file from filePath: %s. Error: %v", filePath, err)
 			}
 			c, err := loadConfigFile(r)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("Could not read and load config file: %v", err)
 			}
 			authFileConfig, err := c.GetAuthConfig(registryHostname)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("Could not get auth config (the credentialhelper did not work or was not found): %v", err)
 			}
 			authConfig.Username = authFileConfig.Username
 			authConfig.Password = authFileConfig.Password


### PR DESCRIPTION
This will make errors when handling `~/.docker/config` file and credentialHelpers much more visible. My gut feeling is that some of the 
```
Error: Error pushing docker image: Error response from daemon: Bad parameters and missing X-Registry-Auth: EOF
```
(e.g. from https://github.com/kreuzwerker/terraform-provider-docker/issues/380) originate from failures in interacting with the credential helpers.