### PR TITLE
fix: Fix compile.yaml workflow.

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -10,10 +10,9 @@ on:
     types: ['opened', 'synchronize']
     paths:
       - '**.go'
+      - '!**_test.go'
       - go.mod
       - '.github/workflows/**'
-    paths-ignore:
-      - '**_test.go'
 
 env:
   GOPROXY: https://proxy.golang.org,direct


### PR DESCRIPTION
You cannot use both `paths` and `paths-ignore` at the same time.