### PR TITLE
feat: Add triggers attribute to docker_registry_image

### DIFF
--- a/docs/resources/registry_image.md
+++ b/docs/resources/registry_image.md
@@ -36,6 +36,7 @@ resource "docker_registry_image" "helloworld" {
 - `build` (Block List, Max: 1) Definition for building the image (see [below for nested schema](#nestedblock--build))
 - `insecure_skip_verify` (Boolean) If `true`, the verification of TLS certificates of the server/registry is disabled. Defaults to `false`
 - `keep_remotely` (Boolean) If true, then the Docker image won't be deleted on destroy operation. If this is false, it will delete the image from the docker registry on destroy operation. Defaults to `false`
+- `triggers` (Map of String) A map of arbitrary strings that, when changed, will force the `docker_registry_image` resource to be replaced. This can be used to rebuild an image when contents of source code folders change or to repush a local image
 
 ### Read-Only
 

--- a/internal/provider/resource_docker_registry_image.go
+++ b/internal/provider/resource_docker_registry_image.go
@@ -332,6 +332,13 @@ func resourceDockerRegistryImage() *schema.Resource {
 				},
 			},
 
+			"triggers": {
+				Description: "A map of arbitrary strings that, when changed, will force the `docker_registry_image` resource to be replaced. This can be used to rebuild an image when contents of source code folders change or to repush a local image",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+			},
+
 			"sha256_digest": {
 				Type:        schema.TypeString,
 				Description: "The sha256 digest of the image.",


### PR DESCRIPTION
# Scope
- Add triggers Map attribute to **docker_registry_image**
- This can be used to rebuild an image when contents of source code folders change or to repush a local image

This is inspired from #425, despite the fact that it was mentioned that the build capabilities from `docker_registry_image` will be all migrated to `docker_image`, this can be a temporary solution until the refactoring is done.