### PR TITLE
Adding Support for Windows Paths in Bash

### DIFF
--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -146,7 +146,7 @@ func validateDockerContainerPath() schema.SchemaValidateDiagFunc {
 	return func(v interface{}, p cty.Path) diag.Diagnostics {
 		value := v.(string)
 		var diags diag.Diagnostics
-		if !regexp.MustCompile(`^[a-zA-Z]:\\|^/`).MatchString(value) {
+		if !regexp.MustCompile(`^[a-zA-Z]:[\\/]|^/`).MatchString(value) {
 			diag := diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  fmt.Sprintf("'%v' must be an absolute path", value),


### PR DESCRIPTION
Included support for Absolute Paths in Windows that begin with e.g. `G:/`

Tests performed also with an online RegEx checker: regexr.com/6s741