### PR TITLE
fix: oauth authorization support for azurecr

### DIFF
--- a/internal/provider/authentication_helpers.go
+++ b/internal/provider/authentication_helpers.go
@@ -50,6 +50,12 @@ func isECRRepositoryURL(url string) bool {
 	return ecrRexp.MatchString(url)
 }
 
+func isAzureCRRepositoryURL(url string) bool {
+	// Regexp is based on the azurecr urls shown https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal?tabs=azure-cli#push-image-to-registry
+	var azurecrRexp = regexp.MustCompile(`^.*\.azurecr\.io$`)
+	return azurecrRexp.MatchString(url)
+}
+
 func setupHTTPHeadersForRegistryRequests(req *http.Request, fallback bool) {
 	// We accept schema v2 manifests and manifest lists, and also OCI types
 	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")

--- a/internal/provider/data_source_docker_registry_image.go
+++ b/internal/provider/data_source_docker_registry_image.go
@@ -81,7 +81,7 @@ func getImageDigest(registry string, registryWithProtocol string, image, tag, us
 	}
 
 	if username != "" {
-		if registry != "ghcr.io" && !isECRRepositoryURL(registry) && registry != "gcr.io" {
+		if registry != "ghcr.io" && !isECRRepositoryURL(registry) && !isAzureCRRepositoryURL(registry) && registry != "gcr.io" {
 			req.SetBasicAuth(username, password)
 		} else {
 			if isECRRepositoryURL(registry) {
@@ -147,6 +147,7 @@ func getImageDigest(registry string, registryWithProtocol string, image, tag, us
 
 type TokenResponse struct {
 	Token string
+	AccessToken string `json:"access_token"`
 }
 
 // Parses key/value pairs from a WWW-Authenticate header
@@ -214,7 +215,15 @@ func getAuthToken(authHeader string, username string, password string, client *h
 		return "", fmt.Errorf("Error parsing OAuth token response: %s", err)
 	}
 
-	return token.Token, nil
+	if token.Token != "" {
+		return token.Token, nil
+	}
+
+	if token.AccessToken != "" {
+		return token.AccessToken, nil
+	}
+
+	return "", fmt.Errorf("Error unsupported OAuth response")
 }
 
 func doDigestRequest(req *http.Request, client *http.Client) (*http.Response, error) {

--- a/internal/provider/data_source_docker_registry_image.go
+++ b/internal/provider/data_source_docker_registry_image.go
@@ -146,7 +146,7 @@ func getImageDigest(registry string, registryWithProtocol string, image, tag, us
 }
 
 type TokenResponse struct {
-	Token string
+	Token       string
 	AccessToken string `json:"access_token"`
 }
 

--- a/internal/provider/resource_docker_config_test.go
+++ b/internal/provider/resource_docker_config_test.go
@@ -111,9 +111,9 @@ func TestAccDockerConfig_basicUpdatable(t *testing.T) {
 	})
 }
 
-/////////////
+// ///////////
 // Helpers
-/////////////
+// ///////////
 func testCheckDockerConfigDestroy(ctx context.Context, s *terraform.State) error {
 	client := testAccProvider.Meta().(*ProviderConfig).DockerClient
 	for _, rs := range s.RootModule().Resources {

--- a/internal/provider/resource_docker_container_test.go
+++ b/internal/provider/resource_docker_container_test.go
@@ -818,7 +818,6 @@ func TestAccDockerContainer_uploadSource(t *testing.T) {
 	})
 }
 
-//
 func TestAccDockerContainer_uploadSourceHash(t *testing.T) {
 	var c types.ContainerJSON
 	var firstRunId string
@@ -1606,9 +1605,9 @@ func TestAccDockerContainer_dualstackaddress(t *testing.T) {
 	})
 }
 
-///////////
+// /////////
 // HELPERS
-///////////
+// /////////
 func testAccContainerRunning(resourceName string, container *types.ContainerJSON) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ctx := context.Background()

--- a/internal/provider/resource_docker_secret_test.go
+++ b/internal/provider/resource_docker_secret_test.go
@@ -136,9 +136,9 @@ func TestAccDockerSecret_labels(t *testing.T) {
 	})
 }
 
-/////////////
+// ///////////
 // Helpers
-/////////////
+// ///////////
 func testCheckDockerSecretDestroy(ctx context.Context, s *terraform.State) error {
 	client := testAccProvider.Meta().(*ProviderConfig).DockerClient
 	for _, rs := range s.RootModule().Resources {

--- a/internal/provider/resource_docker_service_funcs.go
+++ b/internal/provider/resource_docker_service_funcs.go
@@ -25,9 +25,9 @@ type convergeConfig struct {
 	delay      time.Duration
 }
 
-/////////////////
+// ///////////////
 // TF CRUD funcs
-/////////////////
+// ///////////////
 func resourceDockerServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var err error
 	client := meta.(*ProviderConfig).DockerClient
@@ -226,9 +226,9 @@ func resourceDockerServiceDelete(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-/////////////////
+// ///////////////
 // Helpers
-/////////////////
+// ///////////////
 // fetchDockerService fetches a service by its name or id
 func fetchDockerService(ctx context.Context, ID string, name string, client *client.Client) (*swarm.Service, error) {
 	apiServices, err := client.ServiceList(ctx, types.ServiceListOptions{})

--- a/internal/provider/resource_docker_service_structures.go
+++ b/internal/provider/resource_docker_service_structures.go
@@ -13,10 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-//////////////
+// ////////////
 // flatteners
 // flatten API objects to the terraform schema
-//////////////
+// ////////////
 // see https://learn.hashicorp.com/tutorials/terraform/provider-create?in=terraform/providers#add-flattening-functions
 func flattenTaskSpec(in swarm.TaskSpec) []interface{} {
 	m := make(map[string]interface{})
@@ -110,7 +110,7 @@ func flattenServiceEndpointSpec(in *swarm.EndpointSpec) []interface{} {
 	return out
 }
 
-///// start TaskSpec
+// /// start TaskSpec
 func flattenContainerSpec(in *swarm.ContainerSpec) []interface{} {
 	out := make([]interface{}, 0)
 	m := make(map[string]interface{})
@@ -525,8 +525,8 @@ func flattenTaskLogDriver(in *swarm.Driver) []interface{} {
 	return out
 }
 
-///// end TaskSpec
-///// start EndpointSpec
+// /// end TaskSpec
+// /// start EndpointSpec
 func flattenServicePorts(in []swarm.PortConfig) []interface{} {
 	out := make([]interface{}, len(in))
 	for i, v := range in {
@@ -543,10 +543,10 @@ func flattenServicePorts(in []swarm.PortConfig) []interface{} {
 
 ///// end EndpointSpec
 
-//////////////
+// ////////////
 // Mappers
 // create API object from the terraform resource schema
-//////////////
+// ////////////
 // createServiceSpec creates the service spec: https://docs.docker.com/engine/api/v1.32/#operation/ServiceCreate
 func createServiceSpec(d *schema.ResourceData) (swarm.ServiceSpec, error) {
 	serviceSpec := swarm.ServiceSpec{

--- a/internal/provider/test_helpers.go
+++ b/internal/provider/test_helpers.go
@@ -38,7 +38,6 @@ const (
 // As a convention the test configurations are in
 // 'testdata/<resourceType>/<resourceName>/<testName>.tf', e.g.
 // 'testdata/resources/docker_container/testAccDockerContainerPrivateImage.tf'
-//
 func loadTestConfiguration(t *testing.T, resourceType resourceType, resourceName, testName string) string {
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
This adds support for authorization with Azure Container Registry.
Previously this would fail for 2 reasons:
1. It was trying to use basic for azurecr
2. It was not looking for the `access_token` in the oauth response