### PR TITLE
Configurable timeout for docker_container resource stateChangeConf

### DIFF
--- a/internal/provider/resource_docker_container.go
+++ b/internal/provider/resource_docker_container.go
@@ -926,6 +926,13 @@ func resourceDockerContainer() *schema.Resource {
 				},
 			},
 
+			"container_read_refresh_timeout": {
+				Type:        schema.TypeInt,
+				Description: "The total number of seconds to wait for the container to reach status 'running'",
+				Optional:    true,
+				Default:     15,
+			},
+
 			"sysctls": {
 				Type:        schema.TypeMap,
 				Description: "A map of kernel parameters (sysctls) to set in the container.",

--- a/internal/provider/resource_docker_container_funcs.go
+++ b/internal/provider/resource_docker_container_funcs.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	containerReadRefreshTimeout             = 15 * time.Second
+	// containerReadRefreshTimeout             = 15 * time.Second
 	containerReadRefreshWaitBeforeRefreshes = 100 * time.Millisecond
 	containerReadRefreshDelay               = 100 * time.Millisecond
 )
@@ -560,6 +560,7 @@ func resourceDockerContainerCreate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceDockerContainerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	containerReadRefreshTimeout := d.Get("container_read_refresh_timeout").(int)
 	log.Printf("[INFO] Waiting for container: '%s' to run: max '%v seconds'", d.Id(), containerReadRefreshTimeout)
 	client := meta.(*ProviderConfig).DockerClient
 
@@ -577,7 +578,7 @@ func resourceDockerContainerRead(ctx context.Context, d *schema.ResourceData, me
 		Pending:    []string{"pending"},
 		Target:     []string{"running"},
 		Refresh:    resourceDockerContainerReadRefreshFunc(ctx, d, meta),
-		Timeout:    containerReadRefreshTimeout,
+		Timeout:    time.Duration(containerReadRefreshTimeout) * time.Second,
 		MinTimeout: containerReadRefreshWaitBeforeRefreshes,
 		Delay:      containerReadRefreshDelay,
 	}

--- a/internal/provider/resource_docker_container_funcs.go
+++ b/internal/provider/resource_docker_container_funcs.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	// containerReadRefreshTimeout             = 15 * time.Second
 	containerReadRefreshWaitBeforeRefreshes = 100 * time.Millisecond
 	containerReadRefreshDelay               = 100 * time.Millisecond
 )


### PR DESCRIPTION
Hi,
The docker_container resource provides a hardcoded timeout for the terraform to wait for the container to be ready. However, it makes sense to have this value be configurable to allow for slower starting containers. The default will remain `15` seconds, with an option to override on a container by container basis. 

