### PR TITLE
fix: Correct provider name to match the public registry

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	opts := &plugin.ServeOpts{ProviderFunc: provider.New(version)}
 
 	if debugMode {
-		debugOpts := &plugin.ServeOpts{ProviderFunc: provider.New(version), ProviderAddr: "registry.terraform.io/kreuzwerker/terraform-provider-docker", Debug: true}
+		debugOpts := &plugin.ServeOpts{ProviderFunc: provider.New(version), ProviderAddr: "registry.terraform.io/kreuzwerker/docker", Debug: true}
 		plugin.Serve(debugOpts)
 		return
 	}


### PR DESCRIPTION
This fixes the following error that shows up if you run the provider in debug mode:

```json
{
  "@level": "info",
  "@message": "2022/09/21 15:25:08 [ERROR] Error parsing provider name \"registry.terraform.io/kreuzwerker/terraform-provider-docker\": Invalid provider type: Provider source \"kreuzwerker/terraform-provider-docker\" has a type with the prefix \"terraform-provider-\", which isn't valid. Although that prefix is often used in the names of version control repositories for Terraform providers, provider source strings should not include it.\n\nDid you mean \"kreuzwerker/docker\"?",
  "@timestamp": "2022-09-21T15:25:08.353718-04:00"
}
```