### PR TITLE
feat: support docker container healthy state

### DIFF
--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -94,6 +94,8 @@ resource "docker_image" "ubuntu" {
 - `user` (String) User used for run the first process. Format is `user` or `user:group` which user and group can be passed literraly or by name.
 - `userns_mode` (String) Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
 - `volumes` (Block Set) Spec for mounting volumes in the container. (see [below for nested schema](#nestedblock--volumes))
+- `wait` (Boolean) If `true`, then the Docker container is waited for being healthy state after creation. If `false`, then the container health state is not checked. Defaults to `false`.
+- `wait_timeout` (Number) The timeout in seconds to wait the container to be healthy after creation. Defaults to `60`.
 - `working_dir` (String) The working directory for commands to run in.
 
 ### Read-Only

--- a/internal/provider/resource_docker_container.go
+++ b/internal/provider/resource_docker_container.go
@@ -64,6 +64,20 @@ func resourceDockerContainer() *schema.Resource {
 				Optional:    true,
 			},
 
+			"wait": {
+				Type:        schema.TypeBool,
+				Description: "If `true`, then the Docker container is waited for being healthy state after creation. If `false`, then the container health state is not checked. Defaults to `false`.",
+				Default:     false,
+				Optional:    true,
+			},
+
+			"wait_timeout": {
+				Type:        schema.TypeInt,
+				Description: "The timeout in seconds to wait the container to be healthy after creation. Defaults to `60`.",
+				Default:     60,
+				Optional:    true,
+			},
+
 			"attach": {
 				Type:        schema.TypeBool,
 				Description: "If `true` attach to the container after its creation and waits the end of its execution. Defaults to `false`.",

--- a/internal/provider/resource_docker_container_test.go
+++ b/internal/provider/resource_docker_container_test.go
@@ -89,6 +89,8 @@ func TestAccDockerContainer_basic(t *testing.T) {
 					"restart",
 					"rm",
 					"start",
+					"wait",
+					"wait_timeout",
 					"container_logs",
 					"destroy_grace_seconds",
 					"upload",
@@ -132,6 +134,8 @@ func TestAccDockerContainer_init(t *testing.T) {
 					"restart",
 					"rm",
 					"start",
+					"wait",
+					"wait_timeout",
 					"container_logs",
 					"destroy_grace_seconds",
 					"upload",
@@ -962,12 +966,12 @@ func TestAccDockerContainer_multipleUploadContentsConfig(t *testing.T) {
 					name         = "nginx:latest"
 					keep_locally = true
 				}
-				
+
 				resource "docker_container" "foo" {
 					name     = "tf-test"
 					image    = docker_image.foo.image_id
 					must_run = "false"
-				
+
 					upload {
 						content        = "foobar"
 						content_base64 = base64encode("barbaz")
@@ -993,12 +997,12 @@ func TestAccDockerContainer_noUploadContentsConfig(t *testing.T) {
 					name         = "nginx:latest"
 					keep_locally = true
 				}
-				
+
 				resource "docker_container" "foo" {
 					name     = "tf-test"
 					image    = docker_image.foo.image_id
 					must_run = "false"
-				
+
 					upload {
 						file           = "/terraform/test1.txt"
 						executable     = true


### PR DESCRIPTION
This feature adds the ability to check and wait for the container healthy state at creation.

Two options are added to the `docker_container`resource:
- `wait` : flag to wait for the healthy state at creation (default `false`)
- `wait_timeout`: the maximal timeout in seconds to wait for (default `60`)

The `wait` option is disabled by default as a `healthcheck` block is required to successfully create the resource. It works too with the `count` option but all containers will be started and checked at the same time for the given resource.

Note that the healthy state is only checked at resource creation not afterwards.

Here is an example:

```
resource "docker_network" "test" {
  name = "test"
}

resource "docker_image" "nginx" {
  name = "bhuisgen/alpine-nginx:prod"
}

resource "docker_container" "test" {
  count = 3

  wait = true
  # wait_timeout = 60

  image       = docker_image.nginx.image_id
  name        = "test_${count.index + 1}"

  healthcheck {
    test         = ["CMD", "/command/s6-svstat", "-u", "/run/service/nginx"]
    interval     = "15s"
    timeout      = "10s"
    start_period = "15s"
    retries      = 3
  }
}
```

```
docker_image.nginx: Creating...
docker_network.test: Creating...
docker_image.nginx: Creation complete after 0s [id=sha256:d83818098350e91cda406e064774182d5d10d217e8bf185e9e0fed6c6abc8ef3bhuisgen/alpine-nginx:prod]
docker_network.test: Creation complete after 2s [id=27dfa73218d0e66d91b9ee4ed34351287a57b060931258e9e60a4a7fe75de032]
docker_container.test[1]: Creating...
docker_container.test[2]: Creating...
docker_container.test[0]: Creating...
docker_container.test[0]: Still creating... [10s elapsed]
docker_container.test[2]: Still creating... [10s elapsed]
docker_container.test[1]: Still creating... [10s elapsed]
docker_container.test[2]: Creation complete after 16s [id=97b821b3dd6a318dc29863305a531eb5c5092c14da16ca8649bdd05e37a88b35]
docker_container.test[1]: Creation complete after 16s [id=f14291b8970041d7575e230f7441eb450df0e6b12429894f1ab729391f2fc7fc]
docker_container.test[0]: Creation complete after 17s [id=42cc700e10246a185f310c781e5627cdd0ff325ffdd7349e5d7a77e59be958fb]
```
