### PR TITLE
fix: Handle Auth Header Scopes

### DIFF
--- a/internal/provider/data_source_docker_registry_image.go
+++ b/internal/provider/data_source_docker_registry_image.go
@@ -158,9 +158,12 @@ func parseAuthHeader(header string) map[string]string {
 
 	for _, part := range parts {
 		vals := strings.SplitN(part, "=", 2)
-		key := vals[0]
-		val := strings.Trim(vals[1], "\", ")
-		opts[key] = val
+
+		if len(vals) == 2 {
+			key := vals[0]
+			val := strings.Trim(vals[1], "\", ")
+			opts[key] = val
+		}
 	}
 
 	return opts

--- a/internal/provider/data_source_docker_registry_image.go
+++ b/internal/provider/data_source_docker_registry_image.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -153,17 +154,14 @@ type TokenResponse struct {
 // Parses key/value pairs from a WWW-Authenticate header
 func parseAuthHeader(header string) map[string]string {
 	parts := strings.SplitN(header, " ", 2)
-	parts = strings.Split(parts[1], ",")
+	parts = regexp.MustCompile(`\w+\=\".*?\"|\w+[^\s\"]+?`).FindAllString(parts[1], -1) // expression to match auth headers.
 	opts := make(map[string]string)
 
 	for _, part := range parts {
 		vals := strings.SplitN(part, "=", 2)
-
-		if len(vals) == 2 {
-			key := vals[0]
-			val := strings.Trim(vals[1], "\", ")
-			opts[key] = val
-		}
+		key := vals[0]
+		val := strings.Trim(vals[1], "\", ")
+		opts[key] = val
 	}
 
 	return opts


### PR DESCRIPTION
As reported in #481, there is an issue with handling auth headers with more than one scope. For example

```
header := "Bearer realm="https://gcr.io/v2/token",service="gcr.io",scope="repository:<owner>/:<repo>/<name>:pull””
```
Works fine with single scopes. However, once we have more than one scope like

```
header := "Bearer realm="https://gcr.io/v2/token",service="gcr.io",scope="repository:<owner>/:<repo>/<name>:push,pull""
```

https://github.com/kreuzwerker/terraform-provider-docker/blob/ffb0cbfb75f5fc331777e33c6eab6c476b9e88cf/internal/provider/data_source_docker_registry_image.go#L156

Essentially returns a trailing map value of ["pull"] which breaks on https://github.com/kreuzwerker/terraform-provider-docker/blob/ffb0cbfb75f5fc331777e33c6eab6c476b9e88cf/internal/provider/data_source_docker_registry_image.go#L162

So this yields something like...
```
realm="https://gcr.io/v2/token"
service="gcr.io"
scope="repository:<owner>/:<repo>/<name>:push"
pull
```
Which causes the error in #481.

This fix ensures that trailing scopes do not cause issues. So now we have...

```
realm="https://gcr.io/v2/token"
service="gcr.io"
scope="repository:<owner>/:<repo>/<name>:push,pull"
```

