### PR TITLE
Default to a garbage username/password to work with Docker private registry v2

### DIFF
--- a/internal/provider/resource_docker_registry_image_funcs.go
+++ b/internal/provider/resource_docker_registry_image_funcs.go
@@ -49,6 +49,7 @@ func resourceDockerRegistryImageCreate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.Errorf("resourceDockerRegistryImageCreate: Unable to get authConfig for registry: %s", err)
 	}
+	log.Printf("TEST")
 	if err := pushDockerRegistryImage(ctx, client, pushOpts, authConfig.Username, authConfig.Password); err != nil {
 		return diag.Errorf("Error pushing docker image: %s", err)
 	}
@@ -418,17 +419,20 @@ func getDockerImageContextTarHash(dockerContextTarPath string) (string, error) {
 
 func pushDockerRegistryImage(ctx context.Context, client *client.Client, pushOpts internalPushImageOptions, username string, password string) error {
 	pushOptions := types.ImagePushOptions{}
+    // start with a dummy because no-auth requires *something*
+	auth := types.AuthConfig{Username: "yourname", Password: "pasword"}
 	if username != "" {
-		auth := types.AuthConfig{Username: username, Password: password}
-		authBytes, err := json.Marshal(auth)
-		if err != nil {
-			return fmt.Errorf("Error creating push options: %s", err)
-		}
-		authBase64 := base64.URLEncoding.EncodeToString(authBytes)
-		pushOptions.RegistryAuth = authBase64
+		auth = types.AuthConfig{Username: username, Password: password}
 	}
+	authBytes, err := json.Marshal(auth)
+	if err != nil {
+		return fmt.Errorf("Error creating push options: %s", err)
+	}
+	authBase64 := base64.URLEncoding.EncodeToString(authBytes)
+	pushOptions.RegistryAuth = authBase64
 
 	out, err := client.ImagePush(ctx, pushOpts.FqName, pushOptions)
+	log.Printf("Got past image push")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #470 

Docker private registry V2 demands something for `X-Registry-Auth` headers, so we toss in a default here if and only if the username is blank. 