### PR TITLE
feat: Support podman

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -75,18 +75,18 @@ func TestAccDockerProvider_WithMultipleRegistryAuth(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	cmd := exec.Command("docker", "version")
+	cmd := exec.Command("podman", "version")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Docker must be available: %s", err)
 	}
 
-	cmd = exec.Command("docker", "node", "ls")
-	if err := cmd.Run(); err != nil {
-		cmd = exec.Command("docker", "swarm", "init")
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("Docker swarm could not be initialized: %s", err)
-		}
-	}
+	// cmd = exec.Command("docker", "node", "ls")
+	// if err := cmd.Run(); err != nil {
+	// 	cmd = exec.Command("docker", "swarm", "init")
+	// 	if err := cmd.Run(); err != nil {
+	// 		t.Fatalf("Docker swarm could not be initialized: %s", err)
+	// 	}
+	// }
 
 	err := testAccProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
 	if err != nil {

--- a/scripts/testacc_cleanup.sh
+++ b/scripts/testacc_cleanup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
+
+shopt -s expand_aliases
+alias docker="podman"
   
 for p in $(docker container ls -f 'name=private_registry' -q); do docker stop $p; done
 echo "### stopped private registry ###"

--- a/scripts/testacc_setup.sh
+++ b/scripts/testacc_setup.sh
@@ -3,7 +3,8 @@ set -e
 
 echo -n "foo" > "$(pwd)/scripts/testing/testingFile"
 echo -n `base64 $(pwd)/scripts/testing/testingFile` > "$(pwd)/scripts/testing/testingFile.base64"
-
+shopt -s expand_aliases
+alias docker="podman"
 # Create self signed certs
 mkdir -p "$(pwd)"/scripts/testing/certs
 openssl req \
@@ -20,18 +21,18 @@ mkdir -p "$(pwd)"/scripts/testing/auth
 # pinned to 2.7.0 due to https://github.com/docker/docker.github.io/issues/11060
 docker run --rm --entrypoint htpasswd registry:2.7.0 -Bbn testuser testpwd > "$(pwd)"/scripts/testing/auth/htpasswd
 docker run -d -p 15000:5000 --rm --name private_registry \
-  -v "$(pwd)"/scripts/testing/auth:/auth \
+  -v /mnt/testing/auth:/auth \
   -e "REGISTRY_AUTH=htpasswd" \
   -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
   -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd" \
-  -v "$(pwd)"/scripts/testing/certs:/certs \
+  -v /mnt/testing/certs:/certs \
   -e "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/registry_auth.crt" \
   -e "REGISTRY_HTTP_TLS_KEY=/certs/registry_auth.key" \
   -e "REGISTRY_STORAGE_DELETE_ENABLED=true" \
   registry:2.7.0
 
 docker run -d -p 15001:5000 --rm --name http_private_registry \
-  -v "$(pwd)"/scripts/testing/auth:/auth \
+  -v /mnt/testing/auth:/auth \
   -e "REGISTRY_AUTH=htpasswd" \
   -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
   -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd" \
@@ -40,19 +41,19 @@ docker run -d -p 15001:5000 --rm --name http_private_registry \
 # wait a bit for travis...
 sleep 5
 # Login to private registry
-docker login -u testuser -p testpwd 127.0.0.1:15000
-docker login -u testuser -p testpwd 127.0.0.1:15001
+docker login -u testuser -p testpwd --tls-verify=false 127.0.0.1:15000
+docker login -u testuser -p testpwd --tls-verify=false 127.0.0.1:15001
 # Build private images
 for i in $(seq 1 3); do 
   docker build -t tftest-service --build-arg MAIN_FILE_PATH=v${i}/main.go "$(pwd)"/scripts/testing -f "$(pwd)"/scripts/testing/Dockerfile
   docker tag tftest-service 127.0.0.1:15000/tftest-service:v${i}
-  docker push 127.0.0.1:15000/tftest-service:v${i}
+  docker push --tls-verify=false 127.0.0.1:15000/tftest-service:v${i}
   docker tag tftest-service 127.0.0.1:15000/tftest-service
-  docker push 127.0.0.1:15000/tftest-service
+  docker push --tls-verify=false 127.0.0.1:15000/tftest-service
   docker tag tftest-service 127.0.0.1:15001/tftest-service:v${i}
-  docker push 127.0.0.1:15001/tftest-service:v${i}
+  docker push --tls-verify=false 127.0.0.1:15001/tftest-service:v${i}
   docker tag tftest-service 127.0.0.1:15001/tftest-service
-  docker push 127.0.0.1:15001/tftest-service
+  docker push --tls-verify=false 127.0.0.1:15001/tftest-service
 done
 # Remove images from host machine before starting the tests
 for i in $(docker images -aq 127.0.0.1:15000/tftest-service); do docker rmi -f "$i"; done

--- a/scripts/testing/Dockerfile
+++ b/scripts/testing/Dockerfile
@@ -4,7 +4,7 @@ ARG MAIN_FILE_PATH
 RUN echo "appuser:x:65534:65534:Appuser:/:" > /etc/passwd
 WORKDIR /build
 COPY $MAIN_FILE_PATH main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o server main.go
+RUN HOME=/root CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o server main.go
 
 FROM alpine
 


### PR DESCRIPTION
This will be an ongoing PR to be able to at least unofficially support podman, so that we can close https://github.com/kreuzwerker/terraform-provider-docker/issues/113

The goal is to be able to run the whole test suite locally (maybe in the future also have the test suit running here in Github)

Current steps:
* Use this PR as the baseline
* Init podman machine with the correct volume: `podman machine init -v "$(pwd)"/scripts/testing:/mnt/testing`
* spin up the testing infrastructure `./scripts/testacc_setup.sh`
* Run some tests: `DOCKER_HOST=unix:///Users/username/.local/share/containers/podman/machine/podman-machine-default/podman.sock TF_LOG=DEBUG TF_ACC=1 go test -v ./internal/provider -timeout 360s -run TestAccDockerContainer`

Issues:

- [ ] Podman complains about our self-signed certificates for our local registries `x509: certificate relies on legacy Common Name field, use SANs instead`