### PR TITLE
feat: Add platform attribute to docker_image resource

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -88,6 +88,7 @@ resource "docker_image" "zoo" {
 - `build` (Block Set, Max: 1) Configuration to build an image. Please see [docker build command reference](https://docs.docker.com/engine/reference/commandline/build/#options) too. (see [below for nested schema](#nestedblock--build))
 - `force_remove` (Boolean) If true, then the image is removed forcibly when the resource is destroyed.
 - `keep_locally` (Boolean) If true, then the Docker image won't be deleted on destroy operation. If this is false, it will delete the image from the docker local storage on destroy operation.
+- `platform` (String) The platform to use when pulling the image. Defaults to the platform of the current machine.
 - `pull_trigger` (String, Deprecated) A value which cause an image pull when changed
 - `pull_triggers` (Set of String) List of values which cause an image pull when changed. This is used to store the image digest from the registry when using the [docker_registry_image](../data-sources/registry_image.md).
 - `triggers` (Map of String) A map of arbitrary strings that, when changed, will force the `docker_image` resource to be replaced. This can be used to rebuild an image when contents of source code folders change

--- a/internal/provider/resource_docker_container_funcs.go
+++ b/internal/provider/resource_docker_container_funcs.go
@@ -51,7 +51,7 @@ func resourceDockerContainerCreate(ctx context.Context, d *schema.ResourceData, 
 	client := meta.(*ProviderConfig).DockerClient
 	authConfigs := meta.(*ProviderConfig).AuthConfigs
 	image := d.Get("image").(string)
-	_, err = findImage(ctx, image, client, authConfigs)
+	_, err = findImage(ctx, image, client, authConfigs, "")
 	if err != nil {
 		return diag.Errorf("Unable to create container with image %s: %s", image, err)
 	}

--- a/internal/provider/resource_docker_image.go
+++ b/internal/provider/resource_docker_image.go
@@ -161,6 +161,13 @@ func resourceDockerImage() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
+			"platform": {
+				Type:        schema.TypeString,
+				Description: "The platform to use when pulling the image. Defaults to the platform of the current machine.",
+				Optional:    true,
+				Default:     "",
+				ForceNew:    true,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_docker_image_test.go
+++ b/internal/provider/resource_docker_image_test.go
@@ -314,6 +314,25 @@ func TestAccDockerImage_tag_sha265(t *testing.T) {
 	})
 }
 
+func TestAccDockerImage_platform(t *testing.T) {
+	ctx := context.Background()
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccDockerImageDestroy(ctx, state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: loadTestConfiguration(t, RESOURCE, "docker_image", "testAccDockerImagePlatform"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("docker_image.foo", "image_id", "sha256:8336f9f1d0946781f428a155536995f0d8a31209d65997e2a379a23e7a441b78"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDockerImage_build(t *testing.T) {
 	ctx := context.Background()
 	wd, _ := os.Getwd()

--- a/testdata/resources/docker_image/testAccDockerImagePlatform.tf
+++ b/testdata/resources/docker_image/testAccDockerImagePlatform.tf
@@ -1,0 +1,4 @@
+resource "docker_image" "foo" {
+  name = "busybox:1.34.0"
+  platform = "linux/amd64"
+}


### PR DESCRIPTION
Implements support for specifying the platform when pulling an image.
Closes #476 