### PR TITLE
feat(container): add MAC address to state

### DIFF
--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -290,6 +290,7 @@ Read-Only:
 - `ip_address` (String)
 - `ip_prefix_length` (Number)
 - `ipv6_gateway` (String)
+- `mac_address` (String)
 - `network_name` (String)
 
 ## Import

--- a/internal/provider/resource_docker_container.go
+++ b/internal/provider/resource_docker_container.go
@@ -615,6 +615,11 @@ func resourceDockerContainer() *schema.Resource {
 							Description: "The IPV6 gateway of the container.",
 							Computed:    true,
 						},
+						"mac_address": {
+							Type:        schema.TypeString,
+							Description: "The MAC address of the container.",
+							Computed:    true,
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_docker_container_migrators.go
+++ b/internal/provider/resource_docker_container_migrators.go
@@ -546,6 +546,10 @@ func resourceDockerContainerV1() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"mac_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_docker_container_structures.go
+++ b/internal/provider/resource_docker_container_structures.go
@@ -74,6 +74,7 @@ func flattenContainerNetworks(in *types.NetworkSettings) []interface{} {
 		m["global_ipv6_address"] = networkData.GlobalIPv6Address
 		m["global_ipv6_prefix_length"] = networkData.GlobalIPv6PrefixLen
 		m["ipv6_gateway"] = networkData.IPv6Gateway
+		m["mac_address"] = networkData.MacAddress
 		out = append(out, m)
 	}
 	return out

--- a/internal/provider/resource_docker_container_test.go
+++ b/internal/provider/resource_docker_container_test.go
@@ -1508,6 +1508,7 @@ func TestAccDockerContainer_ipv4address(t *testing.T) {
 					testAccContainerRunning("docker_container.foo", &c),
 					testCheck,
 					resource.TestCheckResourceAttr("docker_container.foo", "name", "tf-test"),
+					resource.TestCheckResourceAttrSet("docker_container.foo", "network_data.0.mac_address"),
 				),
 			},
 		},


### PR DESCRIPTION
Add the container MAC address for each network into state, so it can be referenced if needed.

I didn't feel this needed a dedicated test case, so I just added a check on an existing one. Please let me know if you feel otherwise.