### PR TITLE
docs: add notes regarding remote builds and context

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -45,6 +45,8 @@ resource "docker_image" "ubuntu" {
 
 You can also use the resource to build an image.
 In this case the image "zoo" and "zoo:develop" are built.
+The `context` and `dockerfile` arguments are relative to the local Terraform process (`path.cwd`).
+There is no need to copy the files to remote hosts before creating the resource.
 
 ```terraform
 resource "docker_image" "zoo" {
@@ -103,7 +105,7 @@ resource "docker_image" "zoo" {
 
 Required:
 
-- `context` (String) Value to specify the build context. Currently, only a `PATH` context is supported. You can use the helper function '${path.cwd}/context-dir'. Please see https://docs.docker.com/build/building/context/ for more information about build contexts.
+- `context` (String) Value to specify the build context. Currently, only a `PATH` context is supported. You can use the helper function '${path.cwd}/context-dir'. This always refers to the local working directory, even when building images on remote hosts. Please see https://docs.docker.com/build/building/context/ for more information about build contexts.
 
 Optional:
 


### PR DESCRIPTION
## Problem to solve
I mistakenly thought I had to copy my Dockerfile and other files relevant to the build to the remote host where I wanted to build the image before the `docker_image` resource creation. 

## How to reproduce
```shell
$ terraform version
Terraform v1.3.9
on linux_amd64
```
Summary of Terraform configuration:
```terraform
terraform {
  required_version = ">= 1.3"
  required_providers {
    docker = {
      source = "kreuzwerker/docker"
      version = "3.0.2"
    }
  }
}

variable "target_host" {
  description = "IP of the VM to target"
  type        = string
  validation {
    condition     = cidrhost("${var.target_host}/32", 0) == var.target_host
    error_message = "target_host must be a valid IP address"
  }
}
provider "docker" {
  host = "ssh://root@${var.target_host}"
}

resource "docker_image" "recursor" {
  name = "recursor"
  build {
    context    = "/opt/recursor"
    tag        = ["recursor:current"]
    dockerfile = "/opt/recursor/Dockerfile"
  }
}
```
Original error I encountered:
```shell
docker_image.recursor: Creating...
docker_image.recursor: Still creating... [10s elapsed]
╷
│ Error: failed to solve with frontend dockerfile.v0: failed to read dockerfile: open /var/lib/docker/tmp/buildkit-mount4152034525/opt/recursor/Dockerfile: no such file or directory
│ 
│ 
│ 
│   with docker_image.recursor,
│   on dns_recursor.tf line 38, in resource "docker_image" "recursor":
│   38: resource "docker_image" "recursor" {
│ 
╵
```

## How to solve
I eventually figured out that the build would work when I set `build.context = "."` on `resource.docker_image.recursor`. 

I added a few comments in the documentation to clarify that the build context is local even when the provider is configured with a remote host.