### PR TITLE
feat: Support to docker config labels

### DIFF
--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -95,9 +95,21 @@ resource "docker_service" "service" {
 - `data` (String) Base64-url-safe-encoded config data
 - `name` (String) User-defined name of the config
 
+### Optional
+
+- `labels` (Block Set) User-defined key/value metadata (see [below for nested schema](#nestedblock--labels))
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--labels"></a>
+### Nested Schema for `labels`
+
+Required:
+
+- `label` (String) Name of the label
+- `value` (String) Value of the label
 
 ## Import
 

--- a/internal/provider/resource_docker_config_test.go
+++ b/internal/provider/resource_docker_config_test.go
@@ -157,3 +157,38 @@ func testAccServiceConfigCreated(resourceName string, config *swarm.Config) reso
 
 	}
 }
+
+func TestAccDockerConfig_labels(t *testing.T) {
+	ctx := context.Background()
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(state *terraform.State) error {
+			return testCheckDockerSecretDestroy(ctx, state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "docker_config" "foo" {
+					name = "foo-config"
+					data = "Ymxhc2RzYmxhYmxhMTI0ZHNkd2VzZA=="
+					labels {
+						label = "test1"
+						value = "foo"
+					}
+					labels {
+						label = "test2"
+						value = "bar"
+					}
+				}
+				`,
+				Check: testCheckLabelMap("docker_config.foo", "labels",
+					map[string]string{
+						"test1": "foo",
+						"test2": "bar",
+					},
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Hello!

Noticed that docker config resource is lacking support for labels and though that instead giving feature request, I'll do the implementation. What do you think?

* Commit message should follow the semantic versioning
* Implementation follows same pattern that was already done for secrets
* There is tests for the labels
* And of course documentation were updated

Anything I missed?