### PR TITLE
Update glob pattern in image docs

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -71,7 +71,7 @@ resource "docker_image" "zoo" {
     context = "."
   }
   triggers = {
-    dir_sha1 = sha1(join("", [for f in fileset(path.module, "src/*") : filesha1(f)]))
+    dir_sha1 = sha1(join("", [for f in fileset(path.module, "src/**") : filesha1(f)]))
   }
 }
 ```


### PR DESCRIPTION
The glob pattern specified in the current docs (`src/*`) does not work on my machine, as it only matches top-level files in `src`. `src/**` matches files in all subdirectories, which I suspect is the indented behavior.