### PR TITLE
fix: resource_docker_service tmpfs mounts #563

### DIFF
--- a/internal/provider/resource_docker_service_structures.go
+++ b/internal/provider/resource_docker_service_structures.go
@@ -254,7 +254,7 @@ func flattenServiceMounts(in []mount.Mount) *schema.Set {
 			tmpfsOptionsItem := make(map[string]interface{})
 
 			tmpfsOptionsItem["size_bytes"] = int(v.TmpfsOptions.SizeBytes)
-			tmpfsOptionsItem["mode"] = v.TmpfsOptions.Mode.Perm
+			tmpfsOptionsItem["mode"] = int(v.TmpfsOptions.Mode.Perm())
 
 			tmpfsOptions = append(tmpfsOptions, tmpfsOptionsItem)
 			m["tmpfs_options"] = tmpfsOptions
@@ -832,7 +832,7 @@ func createContainerSpec(v interface{}) (*swarm.ContainerSpec, error) {
 							for _, rawTmpfsOptions := range value.([]interface{}) {
 								rawTmpfsOptions := rawTmpfsOptions.(map[string]interface{})
 								if value, ok := rawTmpfsOptions["size_bytes"]; ok {
-									mountInstance.TmpfsOptions.SizeBytes = value.(int64)
+									mountInstance.TmpfsOptions.SizeBytes = int64(value.(int))
 								}
 								if value, ok := rawTmpfsOptions["mode"]; ok {
 									mountInstance.TmpfsOptions.Mode = os.FileMode(value.(int))


### PR DESCRIPTION
terraform schemas can only work with int type which is either int32 or int64 equivalent depending on architecture, but the Docker lib expects an int64 for the size_bytes. Previously, the code assumed that the terraform schema would return an int64, which lead to provider crashes.

values are now being converted between int64 and int to handle this. The downside is possible value truncation: resources managed by Terraform can't have tmpfs size_bytes greater than just under 2 GiB (2147483647 byes by golang spec), which can lead to false information if the physical service has been modified to a tmfs size_bytes greater than that outside of terraform, because the int64->int conversion will possibly truncate that on go implementations where int is equivalent to int32.

As long as the limitiation of only TypeInt being available in the schema (and not e.g. TypeInt64) there will be no clean solution to this. An improvement could be to switch to either TypeFloat (53 bits of accuracy, still with the issue, but much less likely to impact in real life, it's 8TiB) or TypeString and convert the numbers between string representations. Both options exceed my Go capabilities though, I think.