### PR TITLE
style: fix spelling mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -545,7 +545,7 @@
 
 ### Ci
 
-* reactivats all workflows
+* reactivates all workflows
 * fix website
 * only run website workflow
 * exports gopath manually

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -86,7 +86,7 @@ website-link-check:
 website-lint:
 	@echo "==> Checking website against linters..."
 	@misspell -error -source=text docs/ || (echo; \
-		echo "Unexpected mispelling found in website files."; \
+		echo "Unexpected misspelling found in website files."; \
 		echo "To automatically fix the misspelling, run 'make website-lint-fix' and commit the changes."; \
 		exit 1)
 	@docker run --rm -v $(PWD):/markdown 06kellyjac/markdownlint-cli docs/ || (echo; \
@@ -113,8 +113,8 @@ chlog-%:
 	@echo "Review the changes made by this script then execute the following:"
 
 
-replace-occurences-%:
-	@echo "Replace occurences of old version strings..."
+replace-occurrences-%:
+	@echo "Replace occurrences of old version strings..."
 	sed -i '' "s/$(shell (svu --strip-prefix current))/$*/g" README.md docs/index.md examples/provider/provider-tf12.tf examples/provider/provider-tf13.tf
 
 release-%:
@@ -130,15 +130,15 @@ release-%:
 
 patch:
 	@${MAKE} chlog-$(shell (svu patch))
-	@${MAKE} replace-occurences-$(shell (svu --strip-prefix patch))
+	@${MAKE} replace-occurrences-$(shell (svu --strip-prefix patch))
 	@${MAKE} release-$(shell (svu patch))
 
 minor:
 	@${MAKE} chlog-$(shell (svu minor))
-	@${MAKE} replace-occurences-$(shell (svu --strip-prefix minor))
+	@${MAKE} replace-occurrences-$(shell (svu --strip-prefix minor))
 	@${MAKE} release-$(shell (svu minor))
 
 major:
 	@${MAKE} chlog-$(shell (svu major))
-	@${MAKE} replace-occurences-$(shell (svu --strip-prefix major))
+	@${MAKE} replace-occurrences-$(shell (svu --strip-prefix major))
 	@${MAKE} release-$(shell (svu major))

--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -3,12 +3,12 @@
 page_title: "docker_image Data Source - terraform-provider-docker"
 subcategory: ""
 description: |-
-  docker_image provides details about a specific Docker Image which need to be presend on the Docker Host
+  docker_image provides details about a specific Docker Image which need to be present on the Docker Host
 ---
 
 # docker_image (Data Source)
 
-`docker_image` provides details about a specific Docker Image which need to be presend on the Docker Host
+`docker_image` provides details about a specific Docker Image which need to be present on the Docker Host
 
 ## Example Usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ provider "docker" {
 }
 ```
 
-When using a remote host, the daemon configuration on the remote host can apply default configuration to your resources when running `terraform apply`, for example by appling log options to containers. When running `terraform plan` the next time, it will show up as a diff. In such cases it is recommended to use the `ignore_changes` lifecycle meta-argument to ignore the changing attribute (See [this issue](https://github.com/kreuzwerker/terraform-provider-docker/issues/473) for more information).
+When using a remote host, the daemon configuration on the remote host can apply default configuration to your resources when running `terraform apply`, for example by applying log options to containers. When running `terraform plan` the next time, it will show up as a diff. In such cases it is recommended to use the `ignore_changes` lifecycle meta-argument to ignore the changing attribute (See [this issue](https://github.com/kreuzwerker/terraform-provider-docker/issues/473) for more information).
 
 ## Registry credentials
 
@@ -124,7 +124,7 @@ When passing in a config file either the corresponding `auth` string of the repo
 used to retrieve the authentication credentials.
 
 -> **Note**
-`config_file` has predence over all other options. You can theoretically specify values for every attribute but the credentials obtained through the `config_file` will override the manually set `username`/`password`
+`config_file` has precedence over all other options. You can theoretically specify values for every attribute but the credentials obtained through the `config_file` will override the manually set `username`/`password`
 
 You can still use the environment variables `DOCKER_REGISTRY_USER` and `DOCKER_REGISTRY_PASS`.
 
@@ -184,7 +184,7 @@ Required:
 Optional:
 
 - `auth_disabled` (Boolean) Setting this to `true` will tell the provider that this registry does not need authentication. Due to the docker internals, the provider will use dummy credentials (see https://github.com/kreuzwerker/terraform-provider-docker/issues/470 for more information). Defaults to `false`.
-- `config_file` (String) Path to docker json file for registry auth. Defaults to `~/.docker/config.json`. If `DOCKER_CONFIG` is set, the value of `DOCKER_CONFIG` is used as the path. `config_file` has predencen over all other options.
+- `config_file` (String) Path to docker json file for registry auth. Defaults to `~/.docker/config.json`. If `DOCKER_CONFIG` is set, the value of `DOCKER_CONFIG` is used as the path. `config_file` has precedence over all other options.
 - `config_file_content` (String) Plain content of the docker json file for registry auth. `config_file_content` has precedence over username/password.
 - `password` (String, Sensitive) Password for the registry. Defaults to `DOCKER_REGISTRY_PASS` env variable if set.
 - `username` (String) Username for the registry. Defaults to `DOCKER_REGISTRY_USER` env variable if set.

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -36,7 +36,7 @@ resource "docker_image" "ubuntu" {
 ### Optional
 
 - `attach` (Boolean) If `true` attach to the container after its creation and waits the end of its execution. Defaults to `false`.
-- `capabilities` (Block Set, Max: 1) Add or drop certrain linux capabilities. (see [below for nested schema](#nestedblock--capabilities))
+- `capabilities` (Block Set, Max: 1) Add or drop certain linux capabilities. (see [below for nested schema](#nestedblock--capabilities))
 - `cgroupns_mode` (String) Cgroup namespace mode to use for the container. Possible values are: `private`, `host`.
 - `command` (List of String) The command to use to start the container. For example, to run `/usr/bin/myprogram -f baz.conf` set the command to be `["/usr/bin/myprogram","-f","baz.con"]`.
 - `container_read_refresh_timeout_milliseconds` (Number) The total number of milliseconds to wait for the container to reach status 'running'
@@ -48,7 +48,7 @@ resource "docker_image" "ubuntu" {
 - `dns_opts` (Set of String) DNS options used by the DNS provider(s), see `resolv.conf` documentation for valid list of options.
 - `dns_search` (Set of String) DNS search domains that are used when bare unqualified hostnames are used inside of the container.
 - `domainname` (String) Domain name of the container.
-- `entrypoint` (List of String) The command to use as the Entrypoint for the container. The Entrypoint allows you to configure a container to run as an executable. For example, to run `/usr/bin/myprogram` when starting a container, set the entrypoint to be `"/usr/bin/myprogra"]`.
+- `entrypoint` (List of String) The command to use as the Entrypoint for the container. The Entrypoint allows you to configure a container to run as an executable. For example, to run `/usr/bin/myprogram` when starting a container, set the entrypoint to be `"/usr/bin/myprogram"]`.
 - `env` (Set of String) Environment variables to set in the form of `KEY=VALUE`, e.g. `DEBUG=0`
 - `gpus` (String) GPU devices to add to the container. Currently, only the value `all` is supported. Passing any other value will result in unexpected behavior.
 - `group_add` (Set of String) Additional groups for the container user
@@ -89,7 +89,7 @@ resource "docker_image" "ubuntu" {
 - `tty` (Boolean) If `true`, allocate a pseudo-tty (`docker run -t`). Defaults to `false`.
 - `ulimit` (Block Set) Ulimit options to add. (see [below for nested schema](#nestedblock--ulimit))
 - `upload` (Block Set) Specifies files to upload to the container before starting it. Only one of `content` or `content_base64` can be set and at least one of them has to be set. (see [below for nested schema](#nestedblock--upload))
-- `user` (String) User used for run the first process. Format is `user` or `user:group` which user and group can be passed literraly or by name.
+- `user` (String) User used for run the first process. Format is `user` or `user:group` which user and group can be passed literally or by name.
 - `userns_mode` (String) Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
 - `volumes` (Block Set) Spec for mounting volumes in the container. (see [below for nested schema](#nestedblock--volumes))
 - `wait` (Boolean) If `true`, then the Docker container is waited for being healthy state after creation. If `false`, then the container health state is not checked. Defaults to `false`.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -602,7 +602,7 @@ Optional:
 
 Optional:
 
-- `memory_bytes` (Number) The amounf of memory in bytes the container allocates
+- `memory_bytes` (Number) The amount of memory in bytes the container allocates
 - `nano_cpus` (Number) CPU shares in units of `1/1e9` (or `10^-9`) of the CPU. Should be at least `1000000`
 
 
@@ -612,7 +612,7 @@ Optional:
 Optional:
 
 - `generic_resources` (Block List, Max: 1) User-defined resources can be either Integer resources (e.g, `SSD=3`) or String resources (e.g, GPU=UUID1) (see [below for nested schema](#nestedblock--task_spec--resources--reservation--generic_resources))
-- `memory_bytes` (Number) The amounf of memory in bytes the container allocates
+- `memory_bytes` (Number) The amount of memory in bytes the container allocates
 - `nano_cpus` (Number) CPU shares in units of 1/1e9 (or 10^-9) of the CPU. Should be at least `1000000`
 
 <a id="nestedblock--task_spec--resources--reservation--generic_resources"></a>
@@ -678,7 +678,7 @@ Required:
 Optional:
 
 - `name` (String) A random name for the port
-- `protocol` (String) Rrepresents the protocol of a port: `tcp`, `udp` or `sctp`. Defaults to `tcp`.
+- `protocol` (String) Represents the protocol of a port: `tcp`, `udp` or `sctp`. Defaults to `tcp`.
 - `publish_mode` (String) Represents the mode in which the port is to be published: 'ingress' or 'host'. Defaults to `ingress`.
 - `published_port` (Number) The port on the swarm hosts
 

--- a/internal/provider/data_source_docker_image.go
+++ b/internal/provider/data_source_docker_image.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceDockerImage() *schema.Resource {
 	return &schema.Resource{
-		Description: "`docker_image` provides details about a specific Docker Image which need to be presend on the Docker Host",
+		Description: "`docker_image` provides details about a specific Docker Image which need to be present on the Docker Host",
 
 		ReadContext: dataSourceDockerImageRead,
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -123,7 +123,7 @@ func New(version string) func() *schema.Provider {
 								Type:        schema.TypeString,
 								Optional:    true,
 								DefaultFunc: schema.EnvDefaultFunc("DOCKER_CONFIG", "~/.docker/config.json"),
-								Description: "Path to docker json file for registry auth. Defaults to `~/.docker/config.json`. If `DOCKER_CONFIG` is set, the value of `DOCKER_CONFIG` is used as the path. `config_file` has predencen over all other options.",
+								Description: "Path to docker json file for registry auth. Defaults to `~/.docker/config.json`. If `DOCKER_CONFIG` is set, the value of `DOCKER_CONFIG` is used as the path. `config_file` has precedence over all other options.",
 							},
 
 							"config_file_content": {
@@ -278,7 +278,7 @@ func providerSetToRegistryAuth(authList *schema.Set) (*AuthConfigs, error) {
 			log.Println("[DEBUG] Parsing file for registry auths:", filePath)
 
 			// We manually expand the path and do not use the 'pathexpand' interpolation function
-			// because in the default of this varable we refer to '~/.docker/config.json'
+			// because in the default of this variable we refer to '~/.docker/config.json'
 			if strings.HasPrefix(filePath, "~/") {
 				usr, err := user.Current()
 				if err != nil {

--- a/internal/provider/resource_docker_container.go
+++ b/internal/provider/resource_docker_container.go
@@ -25,7 +25,7 @@ func resourceDockerContainer() *schema.Resource {
 				Version: 1,
 				Type:    resourceDockerContainerV1().CoreConfigSchema().ImpliedType(),
 				Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-					// TODO do the ohter V0-to-V1 migration, unless we're okay
+					// TODO do the other V0-to-V1 migration, unless we're okay
 					// with breaking for users who straggled on their docker
 					// provider version
 
@@ -162,7 +162,7 @@ func resourceDockerContainer() *schema.Resource {
 
 			"entrypoint": {
 				Type:        schema.TypeList,
-				Description: "The command to use as the Entrypoint for the container. The Entrypoint allows you to configure a container to run as an executable. For example, to run `/usr/bin/myprogram` when starting a container, set the entrypoint to be `\"/usr/bin/myprogra\"]`.",
+				Description: "The command to use as the Entrypoint for the container. The Entrypoint allows you to configure a container to run as an executable. For example, to run `/usr/bin/myprogram` when starting a container, set the entrypoint to be `\"/usr/bin/myprogram\"]`.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
@@ -171,7 +171,7 @@ func resourceDockerContainer() *schema.Resource {
 
 			"user": {
 				Type:        schema.TypeString,
-				Description: "User used for run the first process. Format is `user` or `user:group` which user and group can be passed literraly or by name.",
+				Description: "User used for run the first process. Format is `user` or `user:group` which user and group can be passed literally or by name.",
 				Optional:    true,
 				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -252,7 +252,7 @@ func resourceDockerContainer() *schema.Resource {
 			},
 			"capabilities": {
 				Type:        schema.TypeSet,
-				Description: "Add or drop certrain linux capabilities.",
+				Description: "Add or drop certain linux capabilities.",
 				Optional:    true,
 				ForceNew:    true,
 				MaxItems:    1,

--- a/internal/provider/resource_docker_container_funcs.go
+++ b/internal/provider/resource_docker_container_funcs.go
@@ -906,7 +906,7 @@ func resourceDockerContainerDelete(ctx context.Context, d *schema.ResourceData, 
 		if !containsIgnorableErrorMessage(err.Error(), "No such container", "is already in progress") {
 			return diag.Errorf("Error waiting for container removal '%s': %s", d.Id(), err)
 		}
-		log.Printf("[INFO] Waiting for Container '%s' errord: '%s'", d.Id(), err.Error())
+		log.Printf("[INFO] Waiting for Container '%s' error: '%s'", d.Id(), err.Error())
 	}
 
 	d.SetId("")

--- a/internal/provider/resource_docker_container_migrators.go
+++ b/internal/provider/resource_docker_container_migrators.go
@@ -493,19 +493,19 @@ func resourceDockerContainerV1() *schema.Resource {
 			"ip_address": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "Use ip_adresses_data instead. This field exposes the data of the container's first network.",
+				Deprecated: "Use network_data instead. This field exposes the data of the container's first network.",
 			},
 
 			"ip_prefix_length": {
 				Type:       schema.TypeInt,
 				Computed:   true,
-				Deprecated: "Use ip_prefix_length from ip_adresses_data instead. This field exposes the data of the container's first network.",
+				Deprecated: "Use ip_prefix_length from network_data instead. This field exposes the data of the container's first network.",
 			},
 
 			"gateway": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "Use gateway from ip_adresses_data instead. This field exposes the data of the container's first network.",
+				Deprecated: "Use gateway from network_data instead. This field exposes the data of the container's first network.",
 			},
 
 			"bridge": {

--- a/internal/provider/resource_docker_container_test.go
+++ b/internal/provider/resource_docker_container_test.go
@@ -771,12 +771,12 @@ func TestAccDockerContainer_uploadSource(t *testing.T) {
 
 		// we directly exec the container and print the creation timestamp
 		// which is easier to use the native docker sdk, by creating, running and attaching a reader to the command.
-		execReponse, err := exec.Command("docker", "exec", "-t", "tf-test", "find", "/terraform", "-maxdepth", "1", "-name", "test.txt", "-printf", "%CY-%Cm-%Cd").Output()
+		execResponse, err := exec.Command("docker", "exec", "-t", "tf-test", "find", "/terraform", "-maxdepth", "1", "-name", "test.txt", "-printf", "%CY-%Cm-%Cd").Output()
 		if err != nil {
 			return fmt.Errorf("Unable to exec command: %s", err)
 		}
 
-		fileCreationTime, err := time.Parse("2006-01-02", string(execReponse))
+		fileCreationTime, err := time.Parse("2006-01-02", string(execResponse))
 		if err != nil {
 			return fmt.Errorf("Unable to parse file creation time into format: %s", err)
 		}

--- a/internal/provider/resource_docker_plugin_funcs.go
+++ b/internal/provider/resource_docker_plugin_funcs.go
@@ -206,7 +206,7 @@ func pluginSet(ctx context.Context, d *schema.ResourceData, cl *client.Client) e
 	// path of devices .Settings.Devices
 	// args .Settings.Args
 	if err := cl.PluginSet(ctx, pluginID, getDockerPluginEnv(d.Get("env"))); err != nil {
-		return fmt.Errorf("modifiy settings for the Docker plugin "+pluginID+": %w", err)
+		return fmt.Errorf("modify settings for the Docker plugin "+pluginID+": %w", err)
 	}
 	return nil
 }

--- a/internal/provider/resource_docker_registry_image_test.go
+++ b/internal/provider/resource_docker_registry_image_test.go
@@ -48,7 +48,7 @@ func TestAccDockerRegistryImageResource_buildAndKeep(t *testing.T) {
 			},
 		},
 		// as the providerConfig obtained from testAccProvider.Meta().(*ProviderConfig)
-		// is empty after the test the credetials are passed here manually
+		// is empty after the test the credentials are passed here manually
 		CheckDestroy: testDockerRegistryImageInRegistry("testuser", "testpwd", pushOptions, true),
 	})
 }

--- a/internal/provider/resource_docker_service.go
+++ b/internal/provider/resource_docker_service.go
@@ -530,7 +530,7 @@ func resourceDockerService() *schema.Resource {
 												},
 												"memory_bytes": {
 													Type:        schema.TypeInt,
-													Description: "The amounf of memory in bytes the container allocates",
+													Description: "The amount of memory in bytes the container allocates",
 													Optional:    true,
 												},
 											},
@@ -550,7 +550,7 @@ func resourceDockerService() *schema.Resource {
 												},
 												"memory_bytes": {
 													Type:        schema.TypeInt,
-													Description: "The amounf of memory in bytes the container allocates",
+													Description: "The amount of memory in bytes the container allocates",
 													Optional:    true,
 												},
 												"generic_resources": {
@@ -904,7 +904,7 @@ func resourceDockerService() *schema.Resource {
 									},
 									"protocol": {
 										Type:             schema.TypeString,
-										Description:      "Rrepresents the protocol of a port: `tcp`, `udp` or `sctp`. Defaults to `tcp`.",
+										Description:      "Represents the protocol of a port: `tcp`, `udp` or `sctp`. Defaults to `tcp`.",
 										Default:          "tcp",
 										Optional:         true,
 										ValidateDiagFunc: validateStringMatchesPattern(`^(tcp|udp|sctp)$`),

--- a/internal/provider/resource_docker_service_funcs.go
+++ b/internal/provider/resource_docker_service_funcs.go
@@ -185,7 +185,7 @@ func resourceDockerServiceUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 	if len(updateResponse.Warnings) > 0 {
-		log.Printf("[INFO] Warninig while updating Service '%s': %v", service.ID, updateResponse.Warnings)
+		log.Printf("[INFO] Warning while updating Service '%s': %v", service.ID, updateResponse.Warnings)
 	}
 
 	if v, ok := d.GetOk("converge_config"); ok {
@@ -467,7 +467,7 @@ func resourceDockerServiceUpdateRefreshFunc(ctx context.Context,
 	}
 }
 
-// getActiveNodes gets the actives nodes withon a swarm
+// getActiveNodes gets the actives nodes within a swarm
 func getActiveNodes(ctx context.Context, client *client.Client) (map[string]struct{}, error) {
 	nodes, err := client.NodeList(ctx, types.NodeListOptions{})
 	if err != nil {
@@ -587,7 +587,7 @@ func (u *replicatedConsoleLogUpdater) tasksBySlot(tasks []swarm.Task, activeNode
 }
 
 // terminalState determines if the given state is a terminal state
-// meaninig 'higher' than running (see numberedStates)
+// meaning 'higher' than running (see numberedStates)
 func terminalState(state swarm.TaskState) bool {
 	return numberedStates[state] > numberedStates[swarm.TaskStateRunning]
 }

--- a/internal/provider/resource_docker_service_migrators.go
+++ b/internal/provider/resource_docker_service_migrators.go
@@ -541,7 +541,7 @@ func resourceDockerServiceV1() *schema.Resource {
 												},
 												"memory_bytes": {
 													Type:        schema.TypeInt,
-													Description: "The amounf of memory in bytes the container allocates",
+													Description: "The amount of memory in bytes the container allocates",
 													Optional:    true,
 												},
 											},
@@ -561,7 +561,7 @@ func resourceDockerServiceV1() *schema.Resource {
 												},
 												"memory_bytes": {
 													Type:        schema.TypeInt,
-													Description: "The amounf of memory in bytes the container allocates",
+													Description: "The amount of memory in bytes the container allocates",
 													Optional:    true,
 												},
 												"generic_resources": {
@@ -892,7 +892,7 @@ func resourceDockerServiceV1() *schema.Resource {
 									},
 									"protocol": {
 										Type:             schema.TypeString,
-										Description:      "Rrepresents the protocol of a port: 'tcp', 'udp' or 'sctp'",
+										Description:      "Represents the protocol of a port: 'tcp', 'udp' or 'sctp'",
 										Optional:         true,
 										Default:          "tcp",
 										ValidateDiagFunc: validateStringMatchesPattern(`^(tcp|udp|sctp)$`),
@@ -1424,7 +1424,7 @@ func resourceDockerServiceV0() *schema.Resource {
 												},
 												"memory_bytes": {
 													Type:        schema.TypeInt,
-													Description: "The amounf of memory in bytes the container allocates",
+													Description: "The amount of memory in bytes the container allocates",
 													Optional:    true,
 												},
 											},
@@ -1444,7 +1444,7 @@ func resourceDockerServiceV0() *schema.Resource {
 												},
 												"memory_bytes": {
 													Type:        schema.TypeInt,
-													Description: "The amounf of memory in bytes the container allocates",
+													Description: "The amount of memory in bytes the container allocates",
 													Optional:    true,
 												},
 												"generic_resources": {
@@ -1768,7 +1768,7 @@ func resourceDockerServiceV0() *schema.Resource {
 									},
 									"protocol": {
 										Type:             schema.TypeString,
-										Description:      "Rrepresents the protocol of a port: 'tcp', 'udp' or 'sctp'",
+										Description:      "Represents the protocol of a port: 'tcp', 'udp' or 'sctp'",
 										Optional:         true,
 										Default:          "tcp",
 										ValidateDiagFunc: validateStringMatchesPattern(`^(tcp|udp|sctp)$`),

--- a/internal/provider/resource_docker_service_structures.go
+++ b/internal/provider/resource_docker_service_structures.go
@@ -1034,7 +1034,7 @@ func createGenericResources(value interface{}) ([]swarm.GenericResource, error) 
 	return genericResources, nil
 }
 
-// createRestartPolicy creates the restart poliyc of the service
+// createRestartPolicy creates the restart policy of the service
 func createRestartPolicy(v interface{}) (*swarm.RestartPolicy, error) {
 	restartPolicy := swarm.RestartPolicy{}
 	rawRestartPolicySingleItem := v.([]interface{})
@@ -1088,7 +1088,7 @@ func createPlacement(v interface{}) (*swarm.Placement, error) {
 	return &placement, nil
 }
 
-// createServiceAdvancedNetworks creates the networks the service will be attachted to
+// createServiceAdvancedNetworks creates the networks the service will be attached to
 func createServiceAdvancedNetworks(v interface{}) ([]swarm.NetworkAttachmentConfig, error) {
 	networks := []swarm.NetworkAttachmentConfig{}
 	if len(v.(*schema.Set).List()) > 0 {

--- a/internal/provider/resource_docker_service_test.go
+++ b/internal/provider/resource_docker_service_test.go
@@ -1035,7 +1035,7 @@ func TestAccDockerService_updateMultiplePropertiesConverge(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			// Note mavogel: we download all images upfront and use a data_source then
-			// becausee the test is only flaky in CI. See
+			// because the test is only flaky in CI. See
 			// https://github.com/kreuzwerker/terraform-provider-docker/runs/2732063570
 			pullImageForTest(t, image)
 			pullImageForTest(t, image2)

--- a/internal/provider/test_helpers.go
+++ b/internal/provider/test_helpers.go
@@ -18,7 +18,7 @@ const (
 )
 
 // String converts the the resourceType into
-// the name of the directory the test configuartions
+// the name of the directory the test configurations
 // are int
 func (r resourceType) String() string {
 	return [...]string{

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -58,7 +58,7 @@ func TestValidateStringIsFloatRatio(t *testing.T) {
 func TestValidateDurationGeq0(t *testing.T) {
 	v := "1ms"
 	if diags := validateDurationGeq0()(v, *new(cty.Path)); diags.HasError() {
-		t.Fatalf("%v should be a valid durarion", v)
+		t.Fatalf("%v should be a valid duration", v)
 	}
 
 	v = "-2h"

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -32,7 +32,7 @@ The configuration would look as follows:
 
 {{tffile "examples/provider/provider-ssh.tf"}}
 
-When using a remote host, the daemon configuration on the remote host can apply default configuration to your resources when running `terraform apply`, for example by appling log options to containers. When running `terraform plan` the next time, it will show up as a diff. In such cases it is recommended to use the `ignore_changes` lifecycle meta-argument to ignore the changing attribute (See [this issue](https://github.com/kreuzwerker/terraform-provider-docker/issues/473) for more information).
+When using a remote host, the daemon configuration on the remote host can apply default configuration to your resources when running `terraform apply`, for example by applying log options to containers. When running `terraform plan` the next time, it will show up as a diff. In such cases it is recommended to use the `ignore_changes` lifecycle meta-argument to ignore the changing attribute (See [this issue](https://github.com/kreuzwerker/terraform-provider-docker/issues/473) for more information).
 
 ## Registry credentials
 
@@ -51,7 +51,7 @@ When passing in a config file either the corresponding `auth` string of the repo
 used to retrieve the authentication credentials.
 
 -> **Note**
-`config_file` has predence over all other options. You can theoretically specify values for every attribute but the credentials obtained through the `config_file` will override the manually set `username`/`password`
+`config_file` has precedence over all other options. You can theoretically specify values for every attribute but the credentials obtained through the `config_file` will override the manually set `username`/`password`
 
 You can still use the environment variables `DOCKER_REGISTRY_USER` and `DOCKER_REGISTRY_PASS`.
 


### PR DESCRIPTION
I noticed a typo in the docs and I decided to go through and run a spell-checker ([CSpell](https://cspell.org/)) on the entire repo.

I see that some others have suggested spelling fixes. Some but not all of those happen to be included in this PR.

In resource_docker_container_migrators.go, I mention network_data in the Deprecated note, because there is no evidence of ip_adresses_data or ip_addresses_data ever existing.

Potentially breaks any workflows that rely on the misspelled error messages.