### PR TITLE
feat: add parameters for cpu quota handling

### DIFF
--- a/internal/provider/resource_docker_container.go
+++ b/internal/provider/resource_docker_container.go
@@ -712,6 +712,27 @@ func resourceDockerContainer() *schema.Resource {
 				ValidateDiagFunc: validateStringMatchesPattern(`^\d+([,-]\d+)*$`),
 			},
 
+			"cpus": {
+				Type:             schema.TypeFloat,
+				Description:      "Specify how much of the available CPU resources a container can use.",
+				Optional:         true,
+				ValidateDiagFunc: validateIntegerGeqThan(0),
+			},
+
+			"cpu_period": {
+				Type:             schema.TypeInt,
+				Description:      "Specify the CPU CFS scheduler period, which is used alongside `cpu-quota`.",
+				Optional:         true,
+				ValidateDiagFunc: validateIntegerGeqThan(0),
+			},
+
+			"cpu_quota": {
+				Type:             schema.TypeInt,
+				Description:      "Impose a CPU CFS quota on the container. The number of microseconds per `cpu-period` that the container is limited to before throttled.",
+				Optional:         true,
+				ValidateDiagFunc: validateIntegerGeqThan(0),
+			},
+
 			"log_driver": {
 				Type:        schema.TypeString,
 				Description: "The logging driver to use for the container.",

--- a/internal/provider/resource_docker_container_funcs.go
+++ b/internal/provider/resource_docker_container_funcs.go
@@ -320,6 +320,27 @@ func resourceDockerContainerCreate(ctx context.Context, d *schema.ResourceData, 
 		hostConfig.CpusetCpus = v.(string)
 	}
 
+	if v, ok := d.GetOk("cpus"); ok {
+		hostConfig.CPUPeriod = 100000
+		hostConfig.CPUQuota = int64(v.(float32) * 100000)
+
+		if _, ook := d.GetOk("cpu_period"); ook {
+			log.Printf("[WARN] Value for cpus is set, ignore cpu_period setting")
+		}
+
+		if _, ook := d.GetOk("cpu_quota"); ook {
+			log.Printf("[WARN] Value for cpus is set, ignore cpu_quota setting")
+		}
+	} else {
+		if vv, ook := d.GetOk("cpu_period"); ook {
+			hostConfig.CPUPeriod = int64(vv.(int))
+		}
+
+		if vv, ook := d.GetOk("cpu_quota"); ook {
+			hostConfig.CPUQuota = int64(vv.(int))
+		}
+	}
+
 	if v, ok := d.GetOk("log_opts"); ok {
 		hostConfig.LogConfig.Config = mapTypeMapValsToString(v.(map[string]interface{}))
 	}


### PR DESCRIPTION
This exposes the options cpu_period and cpu_quota to the terraform docker_container resource and adds the convenience parameter `cpus` as it is used by the docker cli.

See https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler for upstream details