### PR TITLE
feat: Support registries that return empty auth scope

### DIFF
--- a/internal/provider/authentication_helpers.go
+++ b/internal/provider/authentication_helpers.go
@@ -127,10 +127,13 @@ func parseAuthHeader(header string) (map[string]string, error) {
 	return opts, nil
 }
 
-func getAuthToken(auth map[string]string, username string, password string, client *http.Client) (string, error) {
+func getAuthToken(auth map[string]string, username string, password string, fallbackScope string, client *http.Client) (string, error) {
 	params := url.Values{}
 	params.Set("service", auth["service"])
 	params.Set("scope", auth["scope"])
+	if auth["scope"] == "" {
+		params.Set("scope", fallbackScope)
+	}
 	tokenRequest, err := http.NewRequest("GET", auth["realm"]+"?"+params.Encode(), nil)
 	if err != nil {
 		return "", fmt.Errorf("Error creating registry request: %s", err)

--- a/internal/provider/data_source_docker_registry_image.go
+++ b/internal/provider/data_source_docker_registry_image.go
@@ -93,7 +93,7 @@ func getImageDigest(registry string, registryWithProtocol string, image, tag, us
 			return "", fmt.Errorf("bad credentials: %s", resp.Status)
 		}
 
-		token, err := getAuthToken(auth, username, password, client)
+		token, err := getAuthToken(auth, username, password, "repository:"+image+":push,pull", client)
 		if err != nil {
 			return "", err
 		}

--- a/internal/provider/data_source_docker_registry_image_manifests.go
+++ b/internal/provider/data_source_docker_registry_image_manifests.go
@@ -114,10 +114,10 @@ func getImageManifest(registry, registryWithProtocol, image, tag, username, pass
 		return nil, err
 	}
 
-	return doManifestRequest(req, client, username, password, true)
+	return doManifestRequest(req, client, username, password, "repository:"+image+":push,pull", true)
 }
 
-func doManifestRequest(req *http.Request, client *http.Client, username string, password string, retryUnauthorized bool) (*ManifestResponse, error) {
+func doManifestRequest(req *http.Request, client *http.Client, username string, password string, fallbackScope string, retryUnauthorized bool) (*ManifestResponse, error) {
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Error during registry request: %s", err)
@@ -135,14 +135,14 @@ func doManifestRequest(req *http.Request, client *http.Client, username string, 
 				return nil, fmt.Errorf("bad credentials: %s", resp.Status)
 			}
 
-			token, err := getAuthToken(auth, username, password, client)
+			token, err := getAuthToken(auth, username, password, fallbackScope, client)
 			if err != nil {
 				return nil, err
 			}
 
 			req.Header.Set("Authorization", "Bearer "+token)
 
-			return doManifestRequest(req, client, username, password, false)
+			return doManifestRequest(req, client, username, password, fallbackScope, false)
 		}
 
 		return nil, fmt.Errorf("got bad response from registry: %s", resp.Status)

--- a/internal/provider/resource_docker_registry_image_funcs.go
+++ b/internal/provider/resource_docker_registry_image_funcs.go
@@ -318,7 +318,7 @@ func deleteDockerRegistryImage(pushOpts internalPushImageOptions, registryWithPr
 			return fmt.Errorf("bad credentials: %s", resp.Status)
 		}
 
-		token, err := getAuthToken(auth, username, password, client)
+		token, err := getAuthToken(auth, username, password, "repository:"+pushOpts.Repository+":*", client)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I've found private docker registry service on hosting provider, that returns "www-authenticate" header without scope. Here is fix for that case.