### PR TITLE
fix authentication to ECR public

### DIFF
--- a/internal/provider/authentication_helpers.go
+++ b/internal/provider/authentication_helpers.go
@@ -41,8 +41,12 @@ func normalizeECRPasswordForDockerCLIUsage(password string) string {
 	return password[4:]
 }
 
+func isECRPublicRepositoryURL(url string) bool {
+	return url == "public.ecr.aws"
+}
+
 func isECRRepositoryURL(url string) bool {
-	if url == "public.ecr.aws" {
+	if isECRPublicRepositoryURL(url) {
 		return true
 	}
 	// Regexp is based on the ecr urls shown in https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html

--- a/internal/provider/authentication_helpers_test.go
+++ b/internal/provider/authentication_helpers_test.go
@@ -4,8 +4,16 @@ import (
 	"testing"
 )
 
-func TestIsECRRepositoryURL(t *testing.T) {
+func TestIsECRPublicRepositoryURL(t *testing.T) {
+	if !isECRPublicRepositoryURL("public.ecr.aws") {
+		t.Fatalf("Expected true")
+	}
+	if isECRPublicRepositoryURL("public.ecr.aws.com") {
+		t.Fatalf("Expected false")
+	}
+}
 
+func TestIsECRRepositoryURL(t *testing.T) {
 	if !isECRRepositoryURL("2385929435838.dkr.ecr.eu-central-1.amazonaws.com") {
 		t.Fatalf("Expected true")
 	}

--- a/internal/provider/data_source_docker_registry_image.go
+++ b/internal/provider/data_source_docker_registry_image.go
@@ -85,7 +85,10 @@ func getImageDigest(registry string, registryWithProtocol string, image, tag, us
 		if registry != "ghcr.io" && !isECRRepositoryURL(registry) && !isAzureCRRepositoryURL(registry) && registry != "gcr.io" {
 			req.SetBasicAuth(username, password)
 		} else {
-			if isECRRepositoryURL(registry) {
+			if isECRPublicRepositoryURL(registry) {
+				password = normalizeECRPasswordForHTTPUsage(password)
+				req.Header.Add("Authorization", "Bearer "+password)
+			} else if isECRRepositoryURL(registry) {
 				password = normalizeECRPasswordForHTTPUsage(password)
 				req.Header.Add("Authorization", "Basic "+password)
 			} else {

--- a/internal/provider/resource_docker_registry_image_funcs.go
+++ b/internal/provider/resource_docker_registry_image_funcs.go
@@ -270,7 +270,10 @@ func deleteDockerRegistryImage(pushOpts internalPushImageOptions, registryWithPr
 		if pushOpts.Registry != "ghcr.io" && !isECRRepositoryURL(pushOpts.Registry) && !isAzureCRRepositoryURL(pushOpts.Registry) && pushOpts.Registry != "gcr.io" {
 			req.SetBasicAuth(username, password)
 		} else {
-			if isECRRepositoryURL(pushOpts.Registry) {
+			if isECRPublicRepositoryURL(pushOpts.Registry) {
+				password = normalizeECRPasswordForHTTPUsage(password)
+				req.Header.Add("Authorization", "Bearer "+password)
+			} else if isECRRepositoryURL(pushOpts.Registry) {
 				password = normalizeECRPasswordForHTTPUsage(password)
 				req.Header.Add("Authorization", "Basic "+password)
 			} else {


### PR DESCRIPTION
It appears that ECR public uses a different authentication mechanism than ECR, this PR make the docker provider compatible with both.

The following example highlights the issue, the provider uses `Authorization: Basic` on ECR public, but the API expects `Authorization: Bearer`:
```
TOKEN=$(aws --region us-east-1 ecr-public get-authorization-token | jq -r .authorizationData.authorizationToken)
```
```
curl -s -H "Authorization: Basic ${TOKEN}" https://public.ecr.aws/v2/docker/library/alpine/tags/list
{"errors":[{"code":"DENIED","message":"Your Authorization Token is invalid."}]}
```
```
curl -s -H "Authorization: Bearer ${TOKEN}" https://public.ecr.aws/v2/docker/library/alpine/tags/list
{"name":"docker/library/alpine","tags":["20240315","3.14.6","3.11.12","3.13.12","3.13","20240923", ...
```

Fixes #622 