### PR TITLE
fix: make container deletion more robust

### DIFF
--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/docker/docker/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -133,4 +134,12 @@ func containsIgnorableErrorMessage(errorMsg string, ignorableErrorMessages ...st
 	}
 
 	return false
+}
+
+func alreadyDeleted(err error) bool {
+	if strings.Contains(err.Error(), "is already in progress") {
+		return true
+	}
+
+	return client.IsErrNotFound(err)
 }

--- a/internal/provider/resource_docker_container_funcs.go
+++ b/internal/provider/resource_docker_container_funcs.go
@@ -886,7 +886,7 @@ func resourceDockerContainerDelete(ctx context.Context, d *schema.ResourceData, 
 
 	log.Printf("[INFO] Removing Container '%s'", d.Id())
 	if err := client.ContainerRemove(ctx, d.Id(), removeOpts); err != nil {
-		if !containsIgnorableErrorMessage(err.Error(), "No such container", "is already in progress") {
+		if !alreadyDeleted(err) {
 			return diag.Errorf("Error deleting container %s: %s", d.Id(), err)
 		}
 	}
@@ -902,7 +902,7 @@ func resourceDockerContainerDelete(ctx context.Context, d *schema.ResourceData, 
 	case waitOk := <-waitOkC:
 		log.Printf("[INFO] Container exited with code [%v]: '%s'", waitOk.StatusCode, d.Id())
 	case err := <-errorC:
-		if !containsIgnorableErrorMessage(err.Error(), "No such container", "is already in progress") {
+		if !alreadyDeleted(err) {
 			return diag.Errorf("Error waiting for container removal '%s': %s", d.Id(), err)
 		}
 		log.Printf("[INFO] Waiting for Container '%s' errord: '%s'", d.Id(), err.Error())


### PR DESCRIPTION
Use the `IsErrNotFound` function exported from the Docker client library to detect HTTP 404 errors returned by the Docker API more reliably.

This improves compatibility with Podman's implementation of the Docker API, because Podman uses a different capitalization for the error message that is returned when a container has already been deleted, causing the existing code to fail to recognize this condition.