### PR TITLE
fix: Set correct default network driver and fix a test

### DIFF
--- a/internal/provider/resource_docker_container.go
+++ b/internal/provider/resource_docker_container.go
@@ -729,19 +729,10 @@ func resourceDockerContainer() *schema.Resource {
 
 			"network_mode": {
 				Type:        schema.TypeString,
-				Description: "Network mode of the container.",
+				Description: "Network mode of the container. See https://docs.docker.com/engine/network/ for more information.",
 				Optional:    true,
 				ForceNew:    true,
-				DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
-					// treat "" as "default", which is Docker's default value
-					if oldV == "" {
-						oldV = "default"
-					}
-					if newV == "" {
-						newV = "default"
-					}
-					return oldV == newV
-				},
+				Default:     "bridge",
 			},
 
 			"networks_advanced": {

--- a/internal/provider/resource_docker_image_test.go
+++ b/internal/provider/resource_docker_image_test.go
@@ -162,12 +162,12 @@ func TestAccDockerImage_private(t *testing.T) {
 
 	testCheckImageInspect := func(*terraform.State) error {
 		if len(i.RepoTags) != 1 ||
-			i.RepoTags[0] != "gcr.io:443/google_containers/pause:0.8.0" {
+			i.RepoTags[0] != "gcr.io:443/google_containers/pause:1.0" {
 			return fmt.Errorf("Image RepoTags is wrong: %v", i.RepoTags)
 		}
 
 		if len(i.RepoDigests) != 1 ||
-			i.RepoDigests[0] != "gcr.io:443/google_containers/pause@sha256:bbeaef1d40778579b7b86543fe03e1ec041428a50d21f7a7b25630e357ec9247" {
+			i.RepoDigests[0] != "gcr.io:443/google_containers/pause@sha256:a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f" {
 			return fmt.Errorf("Image RepoDigests is wrong: %v", i.RepoDigests)
 		}
 

--- a/testdata/data-sources/docker_registry_image/testAccDockerImageDataSourcePrivateConfig.tf
+++ b/testdata/data-sources/docker_registry_image/testAccDockerImageDataSourcePrivateConfig.tf
@@ -1,3 +1,3 @@
 data "docker_registry_image" "bar" {
-  name = "gcr.io:443/google_containers/pause:0.8.0"
+  name = "gcr.io:443/google_containers/pause:1.0"
 }

--- a/testdata/resources/docker_container/testAccDockerContainerNetworksDualStackAddressConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerNetworksDualStackAddressConfig.tf
@@ -7,7 +7,7 @@ resource "docker_network" "test" {
   }
 
   ipam_config {
-    subnet = "fd00::1/64"
+    subnet = "fd00::/64"
   }
 }
 resource "docker_image" "foo" {

--- a/testdata/resources/docker_image/testAddDockerPrivateImageConfig.tf
+++ b/testdata/resources/docker_image/testAddDockerPrivateImageConfig.tf
@@ -1,3 +1,3 @@
 resource "docker_image" "foobar" {
-  name = "gcr.io:443/google_containers/pause:0.8.0"
+  name = "gcr.io:443/google_containers/pause:1.0"
 }


### PR DESCRIPTION
Just trying to fix tests and get everything running again. Default docker networking has changed with newer docker server version. I am also thinking of adding tests to test against different docker server versions, e.g. via a matrix as we do with terraform