### PR TITLE
fix: Implement buildx fixes for general buildkit support and platform handling

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -125,7 +125,7 @@ Optional:
 - `build_args` (Map of String) Pairs for build-time variables in the form of `ENDPOINT : "https://example.com"`
 - `build_id` (String) BuildID is an optional identifier that can be passed together with the build request. The same identifier can be used to gracefully cancel the build with the cancel request.
 - `build_log_file` (String) Path to a file where the buildx log are written to. Only available when `builder` is set. If not set, no logs are available. The path is taken as is, so make sure to use a path that is available.
-- `builder` (String) Set the name of the buildx builder to use. If not set or empty, the legacy builder will be used.
+- `builder` (String) Set the name of the buildx builder to use. Defaults to the `default` builder.
 - `cache_from` (List of String) Images to consider as cache sources
 - `cgroup_parent` (String) Optional parent cgroup for the container
 - `cpu_period` (Number) The length of a CPU period in microseconds
@@ -143,7 +143,7 @@ Optional:
 - `memory_swap` (Number) Total memory (memory + swap), -1 to enable unlimited swap
 - `network_mode` (String) Set the networking mode for the RUN instructions during build
 - `no_cache` (Boolean) Do not use the cache when building the image
-- `platform` (String) Set platform if server is multi-platform capable
+- `platform` (String) Set the target platform for the build. Defaults to `GOOS/GOARCH`. For more information see the [docker documentation](https://github.com/docker/buildx/blob/master/docs/reference/buildx.md#-set-the-target-platforms-for-the-build---platform)
 - `pull_parent` (Boolean) Attempt to pull the image even if an older image exists locally
 - `remote_context` (String) A Git repository URI or HTTP/HTTPS context URI. Will be ignored if `builder` is set.
 - `remove` (Boolean) Remove intermediate containers after a successful build. Defaults to `true`.

--- a/internal/provider/docker_buildx_build.go
+++ b/internal/provider/docker_buildx_build.go
@@ -353,7 +353,7 @@ func mapBuildAttributesToBuildOptions(buildAttributes map[string]interface{}, im
 		options.target = target
 	}
 
-	if platform, ok := buildAttributes["platform"].(string); ok {
+	if platform, ok := buildAttributes["platform"].(string); ok && len(platform) > 0 {
 		options.platforms = append(options.platforms, platform)
 	}
 

--- a/internal/provider/resource_docker_image.go
+++ b/internal/provider/resource_docker_image.go
@@ -388,7 +388,7 @@ func resourceDockerImage() *schema.Resource {
 						},
 						"platform": {
 							Type:        schema.TypeString,
-							Description: "Set platform if server is multi-platform capable",
+							Description: "Set the target platform for the build. Defaults to `GOOS/GOARCH`. For more information see the [docker documentation](https://github.com/docker/buildx/blob/master/docs/reference/buildx.md#-set-the-target-platforms-for-the-build---platform)",
 							Optional:    true,
 							ForceNew:    true,
 						},
@@ -406,8 +406,9 @@ func resourceDockerImage() *schema.Resource {
 						},
 						"builder": {
 							Type:        schema.TypeString,
-							Description: "Set the name of the buildx builder to use. If not set or empty, the legacy builder will be used.",
+							Description: "Set the name of the buildx builder to use. Defaults to the `default` builder.",
 							Optional:    true,
+							Default:     "default",
 							ForceNew:    true,
 						},
 						"build_log_file": {

--- a/internal/provider/resource_docker_image_funcs.go
+++ b/internal/provider/resource_docker_image_funcs.go
@@ -59,13 +59,13 @@ func resourceDockerImageCreate(ctx context.Context, d *schema.ResourceData, meta
 
 				err = runBuild(ctx, dockerCli, options, buildLogFile)
 				if err != nil {
-					return diag.FromErr(err)
+					return diag.Errorf("Error running buildx build: %v", err)
 				}
 			} else {
 
 				err := buildDockerImage(ctx, rawBuild, imageName, client)
 				if err != nil {
-					return diag.FromErr(err)
+					return diag.Errorf("Error running legacy build: %v", err)
 				}
 			}
 		}

--- a/testdata/resources/docker_image/testDockerImageBuildxBuildLog.tf
+++ b/testdata/resources/docker_image/testDockerImageBuildxBuildLog.tf
@@ -4,8 +4,9 @@ resource "docker_image" "test" {
     context      = "."
     dockerfile   = "Dockerfile"
     force_remove = true
-    builder = "default"
-    platform = "linux/amd64"
+    # both commented values are the default values, leaving them there for visibility
+    # builder = "default"
+    # platform = "linux/amd64"
 
     build_log_file = "%s"
   }


### PR DESCRIPTION
* Fixes setting of empty `platform` value in buildx build environments
* Automatically use `default` buildx builder to have continious Buildkit support for people upgrading from older versions