### PR TITLE
feat: Enable resources to have multiple different "docker_client" configured

### DIFF
--- a/internal/provider/data_source_docker_image.go
+++ b/internal/provider/data_source_docker_image.go
@@ -32,7 +32,11 @@ func dataSourceDockerImage() *schema.Resource {
 }
 
 func dataSourceDockerImageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 
 	var data Data
 	if err := fetchLocalImages(ctx, &data, client); err != nil {

--- a/internal/provider/data_source_docker_logs.go
+++ b/internal/provider/data_source_docker_logs.go
@@ -84,7 +84,11 @@ func dataSourceDockerLogs() *schema.Resource {
 }
 
 func dataSourceDockerLogsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	containerId := d.Get("name").(string)
 	d.SetId(containerId)
 

--- a/internal/provider/data_source_docker_network.go
+++ b/internal/provider/data_source_docker_network.go
@@ -101,7 +101,11 @@ func dataSourceDockerNetworkRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("One of id or name must be assigned")
 	}
 
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 
 	network, err := client.NetworkInspect(ctx, name.(string), network.InspectOptions{})
 	if err != nil {

--- a/internal/provider/data_source_docker_plugin.go
+++ b/internal/provider/data_source_docker_plugin.go
@@ -77,7 +77,11 @@ func dataSourceDockerPluginRead(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return err
 	}
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(context.Background(), d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	ctx := context.Background()
 	plugin, _, err := client.PluginInspectWithRaw(ctx, key)
 	if err != nil {

--- a/internal/provider/resource_docker_image.go
+++ b/internal/provider/resource_docker_image.go
@@ -28,6 +28,7 @@ func resourceDockerImage() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"docker_client": dockerSchema,
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/internal/provider/resource_docker_image_funcs.go
+++ b/internal/provider/resource_docker_image_funcs.go
@@ -32,7 +32,13 @@ import (
 )
 
 func resourceDockerImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).DockerClient
+
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
+
 	imageName := d.Get("name").(string)
 
 	if value, ok := d.GetOk("build"); ok {
@@ -86,7 +92,11 @@ func resourceDockerImageCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceDockerImageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	var data Data
 	if err := fetchLocalImages(ctx, &data, client); err != nil {
 		return diag.Errorf("Error reading docker image list: %s", err)
@@ -116,9 +126,13 @@ func resourceDockerImageRead(ctx context.Context, d *schema.ResourceData, meta i
 func resourceDockerImageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// We need to re-read in case switching parameters affects
 	// the value of "latest" or others
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	imageName := d.Get("name").(string)
-	_, err := findImage(ctx, imageName, client, meta.(*ProviderConfig).AuthConfigs, d.Get("platform").(string))
+	_, err = findImage(ctx, imageName, client, meta.(*ProviderConfig).AuthConfigs, d.Get("platform").(string))
 	if err != nil {
 		return diag.Errorf("Unable to read Docker image into resource: %s", err)
 	}
@@ -127,9 +141,13 @@ func resourceDockerImageUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceDockerImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	// TODO mavogel: add retries. see e.g. service updateFailsAndRollbackConvergeConfig test
-	err := removeImage(ctx, d, client)
+	err = removeImage(ctx, d, client)
 	if err != nil {
 		return diag.Errorf("Unable to remove Docker image: %s", err)
 	}
@@ -234,6 +252,8 @@ func pullImage(ctx context.Context, data *Data, client *client.Client, authConfi
 	if err != nil {
 		return fmt.Errorf("error creating auth config: %w", err)
 	}
+
+	fmt.Println(client)
 
 	out, err := client.ImagePull(ctx, imageName, image.PullOptions{
 		RegistryAuth: base64.URLEncoding.EncodeToString(encodedJSON),

--- a/internal/provider/resource_docker_network.go
+++ b/internal/provider/resource_docker_network.go
@@ -22,6 +22,7 @@ func resourceDockerNetwork() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"docker_client": dockerSchema,
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The name of the Docker network.",

--- a/internal/provider/resource_docker_network_funcs.go
+++ b/internal/provider/resource_docker_network_funcs.go
@@ -22,7 +22,11 @@ const (
 )
 
 func resourceDockerNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 
 	createOpts := network.CreateOptions{}
 	if v, ok := d.GetOk("labels"); ok {
@@ -146,7 +150,11 @@ func ipamConfigSetToIpamConfigs(ipamConfigSet *schema.Set) []network.IPAMConfig 
 func resourceDockerNetworkReadRefreshFunc(ctx context.Context,
 	d *schema.ResourceData, meta interface{}) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		client := meta.(*ProviderConfig).DockerClient
+		client, err := NewDockerClient(ctx, d)
+
+		if err != nil {
+			client = meta.(*ProviderConfig).DockerClient
+		}
 		networkID := d.Id()
 
 		retNetwork, _, err := client.NetworkInspectWithRaw(ctx, networkID, network.InspectOptions{})
@@ -192,10 +200,14 @@ func resourceDockerNetworkReadRefreshFunc(ctx context.Context,
 func resourceDockerNetworkRemoveRefreshFunc(ctx context.Context,
 	d *schema.ResourceData, meta interface{}) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		client := meta.(*ProviderConfig).DockerClient
+		client, err := NewDockerClient(ctx, d)
+
+		if err != nil {
+			client = meta.(*ProviderConfig).DockerClient
+		}
 		networkID := d.Id()
 
-		_, _, err := client.NetworkInspectWithRaw(ctx, networkID, network.InspectOptions{})
+		_, _, err = client.NetworkInspectWithRaw(ctx, networkID, network.InspectOptions{})
 		if err != nil {
 			log.Printf("[INFO] Network (%s) not found. Already removed", networkID)
 			return networkID, "removed", nil

--- a/internal/provider/resource_docker_plugin.go
+++ b/internal/provider/resource_docker_plugin.go
@@ -17,6 +17,7 @@ func resourceDockerPlugin() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"docker_client": dockerSchema,
 			"name": {
 				Type:             schema.TypeString,
 				Description:      "Docker Plugin name",

--- a/internal/provider/resource_docker_plugin_funcs.go
+++ b/internal/provider/resource_docker_plugin_funcs.go
@@ -15,7 +15,11 @@ import (
 )
 
 func resourceDockerPluginCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(context.Background(), d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	ctx := context.Background()
 	pluginName := d.Get("name").(string)
 	alias := d.Get("alias").(string)
@@ -48,7 +52,11 @@ func resourceDockerPluginCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceDockerPluginRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(context.Background(), d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	ctx := context.Background()
 	pluginID := d.Id()
 	plugin, _, err := client.PluginInspectWithRaw(ctx, pluginID)
@@ -66,7 +74,11 @@ func resourceDockerPluginRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceDockerPluginDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(context.Background(), d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	ctx := context.Background()
 	pluginID := d.Id()
 	log.Printf("[DEBUG] Remove a Docker plugin " + pluginID)

--- a/internal/provider/resource_docker_registry_image.go
+++ b/internal/provider/resource_docker_registry_image.go
@@ -14,6 +14,7 @@ func resourceDockerRegistryImage() *schema.Resource {
 		UpdateContext: resourceDockerRegistryImageUpdate,
 
 		Schema: map[string]*schema.Schema{
+			"docker_client": dockerSchema,
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The name of the Docker image.",

--- a/internal/provider/resource_docker_registry_image_funcs.go
+++ b/internal/provider/resource_docker_registry_image_funcs.go
@@ -33,7 +33,11 @@ func buildAuthConfigFromResource(v interface{}) registry.AuthConfig {
 }
 
 func resourceDockerRegistryImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	providerConfig := meta.(*ProviderConfig)
 	name := d.Get("name").(string)
 	log.Printf("[DEBUG] Creating docker image %s", name)

--- a/internal/provider/resource_docker_service.go
+++ b/internal/provider/resource_docker_service.go
@@ -19,6 +19,7 @@ func resourceDockerService() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"docker_client": dockerSchema,
 			"auth": {
 				Type:        schema.TypeList,
 				Description: "Configuration for the authentication for pulling the images of the service",

--- a/internal/provider/resource_docker_tag.go
+++ b/internal/provider/resource_docker_tag.go
@@ -10,6 +10,7 @@ func resourceDockerTag() *schema.Resource {
 		ReadContext:   resourceDockerTagRead,
 
 		Schema: map[string]*schema.Schema{
+			"docker_client": dockerSchema,
 			"source_image": {
 				Type:        schema.TypeString,
 				Description: "Name of the source image.",

--- a/internal/provider/resource_docker_tag_funcs.go
+++ b/internal/provider/resource_docker_tag_funcs.go
@@ -8,10 +8,14 @@ import (
 )
 
 func resourceDockerTagCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).DockerClient
+	client, err := NewDockerClient(ctx, d)
+
+	if err != nil {
+		client = meta.(*ProviderConfig).DockerClient
+	}
 	sourceImage := d.Get("source_image").(string)
 	targetImage := d.Get("target_image").(string)
-	err := client.ImageTag(ctx, sourceImage, targetImage)
+	err = client.ImageTag(ctx, sourceImage, targetImage)
 	if err != nil {
 		return diag.Errorf("failed to create docker tag: %s", err)
 	}


### PR DESCRIPTION
This allows containers to be provisioned on different remote hosts

Example usage:

```hcl
terraform {
  required_providers {
    docker = {
      source  = "localdomain/example/docker"
      version = "0.1.0"
    }
  }
}

provider "docker" { }

resource "docker_image" "ubuntu" {
  name = "ubuntu"

  docker_client {
    disable_docker_daemon_check = true
    host = "ssh://root@IP_ADDRESS"
    ssh_opts = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "ConnectTimeout=60000"]
  }
}

resource "docker_container" "foo" {
  name = "test"

  image = docker_image.ubuntu.image_id
  
  docker_client {
    disable_docker_daemon_check = true
    host = "ssh://root@IP_ADDRESS"
    ssh_opts = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "ConnectTimeout=60000"]
  }
}
```

You can now dynamically construct the docker client from provisioned servers.

```hcl
resource "hcloud_server" "server" {
  name        = "my-machine"
  image       = "docker-ce"
  server_type = "cpx11"
  location    = "fsn1"
}

# A docker container with node-exporter
resource "docker_container" "node-exporter" {
  name = "node-exporter"
  image = "quay.io/prometheus/node-exporter:latest"

  # NEW FEATURE
  docker_client {
    host = "ssh://root@${hcloud_server.server.ipv4_address}" 
  }

  restart = "unless-stopped"

  mounts {
    read_only = true
    source    = "/"
    target    = "/host"
    type = "bind"
  }
  
  command = [
    "--path.rootfs=/host"
  ]
}
```
