### PR TITLE
feat: Add CDI device support

### DIFF
--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -45,5 +45,3 @@ data "docker_image" "tag_and_digest" {
 
 - `id` (String) The ID of this resource.
 - `repo_digest` (String) The image sha256 digest in the form of `repo[:tag]@sha256:<hash>`. It may be empty in the edge case where the local image was pulled from a repo, tagged locally, and then referred to in the data source by that local name/tag.
-
-

--- a/docs/data-sources/logs.md
+++ b/docs/data-sources/logs.md
@@ -36,5 +36,3 @@ description: |-
 
 - `id` (String) The ID of this resource.
 - `logs_list_string` (List of String) List of container logs, each element is a line.
-
-

--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -43,5 +43,3 @@ Read-Only:
 - `gateway` (String)
 - `ip_range` (String)
 - `subnet` (String)
-
-

--- a/docs/data-sources/plugin.md
+++ b/docs/data-sources/plugin.md
@@ -39,5 +39,3 @@ data "docker_plugin" "by_id" {
 - `grant_all_permissions` (Boolean) If true, grant all permissions necessary to run the plugin
 - `name` (String) The plugin name. If the tag is omitted, `:latest` is complemented to the attribute value.
 - `plugin_reference` (String) The Docker Plugin Reference
-
-

--- a/docs/data-sources/registry_image.md
+++ b/docs/data-sources/registry_image.md
@@ -38,5 +38,3 @@ resource "docker_image" "ubuntu" {
 
 - `id` (String) The ID of this resource.
 - `sha256_digest` (String) The content digest of the image, as stored in the registry.
-
-

--- a/docs/data-sources/registry_image_manifests.md
+++ b/docs/data-sources/registry_image_manifests.md
@@ -48,5 +48,3 @@ Read-Only:
 - `media_type` (String)
 - `os` (String)
 - `sha256_digest` (String)
-
-

--- a/docs/resources/buildx_builder.md
+++ b/docs/resources/buildx_builder.md
@@ -118,5 +118,3 @@ Optional:
 - `default_load` (Boolean) Automatically load images to the Docker Engine image store. Defaults to `false`
 - `key` (String) Sets the TLS client key.
 - `servername` (String) TLS server name used in requests.
-
-

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -47,7 +47,8 @@ resource "docker_image" "ubuntu" {
 - `cpu_shares` (Number) CPU shares (relative weight) for the container.
 - `cpus` (String) Specify how much of the available CPU resources a container can use. e.g a value of 1.5 means the container is guaranteed at most one and a half of the CPUs. Has precedence over `cpu_period` and `cpu_quota`.
 - `destroy_grace_seconds` (Number) If defined will attempt to stop the container before destroying. Container will be destroyed after `n` seconds or on successful stop.
-- `devices` (Block Set) Bind devices to the container. (see [below for nested schema](#nestedblock--devices))
+- `device_requests` (Block Set) Device requests for the container, such as CDI devices (e.g., `nvidia.com/gpu=all`) or GPU requests. (see [below for nested schema](#nestedblock--device_requests))
+- `devices` (Block Set) Bind traditional devices to the container (e.g., `/dev/nvidia0`). For CDI devices, use `device_requests` instead. (see [below for nested schema](#nestedblock--devices))
 - `dns` (Set of String) DNS servers to use.
 - `dns_opts` (Set of String) DNS options used by the DNS provider(s), see `resolv.conf` documentation for valid list of options.
 - `dns_search` (Set of String) DNS search domains that are used when bare unqualified hostnames are used inside of the container.
@@ -115,6 +116,18 @@ Optional:
 
 - `add` (Set of String) List of linux capabilities to add.
 - `drop` (Set of String) List of linux capabilities to drop.
+
+
+<a id="nestedblock--device_requests"></a>
+### Nested Schema for `device_requests`
+
+Optional:
+
+- `capabilities` (Set of String) List of device capabilities. Only used with `nvidia` driver (e.g., `gpu`, `compute`, `utility`).
+- `count` (Number) Number of devices to request. Use -1 for all devices. Only used with `nvidia` driver.
+- `device_ids` (Set of String) List of device IDs or CDI device identifiers (e.g., `nvidia.com/gpu=all`).
+- `driver` (String) The device driver to use. Common values: `cdi` for CDI devices, `nvidia` for NVIDIA GPU requests.
+- `options` (Map of String) Driver-specific options.
 
 
 <a id="nestedblock--devices"></a>

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -4,7 +4,7 @@ page_title: "Resource docker_image - terraform-provider-docker"
 subcategory: ""
 description: |-
   Manages the lifecycle of a docker image in your docker host. It can be used to build a new docker image or to pull an existing one from a registry.
-   This resource will not pull new layers of the image automatically unless used in conjunction with dockerregistryimage ../data-sources/registry_image.md data source to update the pull_triggers field.
+  This resource will not pull new layers of the image automatically unless used in conjunction with docker_registry_image ../data-sources/registry_image.md data source to update the pull_triggers field.
 ---
 <!-- Bug: Type and Name are switched -->
 # Resource (docker_image)

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -4,7 +4,7 @@ page_title: "Resource docker_service - terraform-provider-docker"
 subcategory: ""
 description: |-
   This resource manages the lifecycle of a Docker service. By default, the creation, update and delete of services are detached.
-   With the Converge Config the behavior of the docker cli is imitated to guarantee tha for example, all tasks of a service are running or successfully updated or to inform terraform that a service could no be updated and was successfully rolled back.
+  With the Converge Config the behavior of the docker cli is imitated to guarantee tha for example, all tasks of a service are running or successfully updated or to inform terraform that a service could no be updated and was successfully rolled back.
 ---
 <!-- Bug: Type and Name are switched -->
 # Resource (docker_service)

--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -28,5 +28,3 @@ Creates a docker tag. It has the exact same functionality as the `docker tag` co
 
 - `id` (String) The ID of this resource.
 - `source_image_id` (String) ImageID of the source image in the format of `sha256:<<ID>>`
-
-

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -111,6 +111,15 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+// testAccCheckNvidiaGPURequired skips test if NVIDIA GPU is not available for CDI testing
+func testAccCheckNvidiaGPURequired(t *testing.T) {
+	// Check if nvidia-smi is available and can detect GPUs
+	cmd := exec.Command("nvidia-smi", "-L")
+	if err := cmd.Run(); err != nil {
+		t.Skip("Skipping CDI test: no NVIDIA GPU detected")
+	}
+}
+
 func TestGetContextHost_ValidContext(t *testing.T) {
 	// Create a temporary directory to simulate Docker contexts
 	tempDir := t.TempDir()

--- a/internal/provider/resource_docker_container.go
+++ b/internal/provider/resource_docker_container.go
@@ -636,7 +636,7 @@ func resourceDockerContainer() *schema.Resource {
 
 			"devices": {
 				Type:        schema.TypeSet,
-				Description: "Bind devices to the container.",
+				Description: "Bind traditional devices to the container (e.g., `/dev/nvidia0`). For CDI devices, use `device_requests` instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Elem: &schema.Resource{
@@ -658,6 +658,59 @@ func resourceDockerContainer() *schema.Resource {
 							Description: "The cgroup permissions given to the container to access the device. Defaults to `rwm`.",
 							Optional:    true,
 							ForceNew:    true,
+						},
+					},
+				},
+			},
+
+			"device_requests": {
+				Type:          schema.TypeSet,
+				Description:   "Device requests for the container, such as CDI devices (e.g., `nvidia.com/gpu=all`) or GPU requests.",
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"gpus"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"driver": {
+							Type:        schema.TypeString,
+							Description: "The device driver to use. Common values: `cdi` for CDI devices, `nvidia` for NVIDIA GPU requests.",
+							Optional:    true,
+							Default:     "cdi",
+							ForceNew:    true,
+						},
+						"count": {
+							Type:        schema.TypeInt,
+							Description: "Number of devices to request. Use -1 for all devices. Only used with `nvidia` driver.",
+							Optional:    true,
+							Default:     0,
+							ForceNew:    true,
+						},
+						"device_ids": {
+							Type:        schema.TypeSet,
+							Description: "List of device IDs or CDI device identifiers (e.g., `nvidia.com/gpu=all`).",
+							Optional:    true,
+							ForceNew:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"capabilities": {
+							Type:        schema.TypeSet,
+							Description: "List of device capabilities. Only used with `nvidia` driver (e.g., `gpu`, `compute`, `utility`).",
+							Optional:    true,
+							ForceNew:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"options": {
+							Type:        schema.TypeMap,
+							Description: "Driver-specific options.",
+							Optional:    true,
+							ForceNew:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 					},
 				},
@@ -954,10 +1007,11 @@ func resourceDockerContainer() *schema.Resource {
 				ForceNew:    true,
 			},
 			"gpus": {
-				Type:        schema.TypeString,
-				Description: "GPU devices to add to the container. Currently, only the value `all` is supported. Passing any other value will result in unexpected behavior.",
-				Optional:    true,
-				ForceNew:    true,
+				Type:          schema.TypeString,
+				Description:   "GPU devices to add to the container. Currently, only the value `all` is supported. Passing any other value will result in unexpected behavior.",
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"device_requests"},
 			},
 			"cpus": {
 				Type:        schema.TypeString,

--- a/internal/provider/resource_docker_container_funcs.go
+++ b/internal/provider/resource_docker_container_funcs.go
@@ -291,6 +291,10 @@ func resourceDockerContainerCreate(ctx context.Context, d *schema.ResourceData, 
 		hostConfig.Devices = deviceSetToDockerDevices(v.(*schema.Set))
 	}
 
+	if v, ok := d.GetOk("device_requests"); ok {
+		hostConfig.DeviceRequests = deviceRequestsSetToDockerRequests(v.(*schema.Set))
+	}
+
 	if v, ok := d.GetOk("dns"); ok {
 		hostConfig.DNS = stringSetToStringSlice(v.(*schema.Set))
 	}
@@ -777,6 +781,39 @@ func resourceDockerContainerRead(ctx context.Context, d *schema.ResourceData, me
 	if err = d.Set("devices", flattenDevices(container.HostConfig.Devices)); err != nil {
 		log.Printf("[WARN] failed to set container hostconfig devices from API: %s", err)
 	}
+	// Handle device_requests and gpus reconstruction
+	if _, hasGpus := d.GetOk("gpus"); hasGpus {
+		// If config has gpus, check if any device request is a GPU request and reconstruct
+		foundGpuRequest := false
+		for _, deviceRequest := range container.HostConfig.DeviceRequests {
+			if deviceRequest.Count == -1 && len(deviceRequest.Capabilities) > 0 {
+				for _, capabilitySet := range deviceRequest.Capabilities {
+					for _, capability := range capabilitySet {
+						if capability == "gpu" {
+							d.Set("gpus", "all")
+							foundGpuRequest = true
+							break
+						}
+					}
+					if foundGpuRequest {
+						break
+					}
+				}
+			}
+			if foundGpuRequest {
+				break
+			}
+		}
+		// When gpus is set in config, always set device_requests to empty (whether GPU was found or not)
+		if err = d.Set("device_requests", []interface{}{}); err != nil {
+			log.Printf("[WARN] failed to set container hostconfig device_requests from API: %s", err)
+		}
+	} else {
+		// Config doesn't have gpus, so include all device requests in state
+		if err = d.Set("device_requests", flattenDeviceRequests(container.HostConfig.DeviceRequests)); err != nil {
+			log.Printf("[WARN] failed to set container hostconfig device_requests from API: %s", err)
+		}
+	}
 	// "destroy_grace_seconds" can't be imported
 	d.Set("memory", container.HostConfig.Memory/1024/1024)
 	if container.HostConfig.MemorySwap > 0 {
@@ -816,13 +853,6 @@ func resourceDockerContainerRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("stdin_open", container.Config.OpenStdin)
 	d.Set("stop_signal", container.Config.StopSignal)
 	d.Set("stop_timeout", container.Config.StopTimeout)
-
-	if len(container.HostConfig.DeviceRequests) > 0 {
-		// TODO pass the original gpus property string back to the resource
-		// var gpuOpts opts.GpuOpts
-		// gpuOpts = opts.GpuOpts{container.HostConfig.DeviceRequests}
-		d.Set("gpus", "all")
-	}
 
 	return nil
 }

--- a/testdata/resources/docker_container/testAccDockerContainerDeviceCDIConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerDeviceCDIConfig.tf
@@ -1,0 +1,13 @@
+resource "docker_image" "foo" {
+  name = "nginx:latest"
+}
+
+resource "docker_container" "foo" {
+  name  = "tf-test"
+  image = docker_image.foo.image_id
+
+  device_requests {
+    driver = "cdi"
+    device_ids = ["nvidia.com/gpu=all"]
+  }
+}

--- a/testdata/resources/docker_container/testAccDockerContainerGpusAllConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerGpusAllConfig.tf
@@ -1,0 +1,9 @@
+resource "docker_image" "foo" {
+  name = "nginx:latest"
+}
+
+resource "docker_container" "foo" {
+  name  = "tf-test"
+  image = docker_image.foo.image_id
+  gpus  = "all"
+}

--- a/testdata/resources/docker_container/testAccDockerContainerGpusAndCDIConfig.tf
+++ b/testdata/resources/docker_container/testAccDockerContainerGpusAndCDIConfig.tf
@@ -1,0 +1,14 @@
+resource "docker_image" "foo" {
+  name = "nginx:latest"
+}
+
+resource "docker_container" "foo" {
+  name  = "tf-test"
+  image = docker_image.foo.image_id
+  gpus  = "all"
+
+  device_requests {
+    driver = "cdi"
+    device_ids = ["nvidia.com/gpu=all"]
+  }
+}


### PR DESCRIPTION
This PR allows users to use the CDI interface to pass through GPUs to their containers instead of using the existing `gpus  = "all"`.

This is needed as operating systems like [nixos](https://discourse.nixos.org/t/virtualisation-docker-enablenvidia-vs-hardware-nvidia-container-toolkit-enable/51370) are removing the support for `gpus all`.

### Changes:
  - Adds CDI (Container Device Interface) device support via a new device_requests field
  - Added ConflictsWith validation between gpus and device_requests
  - Updated documentation
  - Added tests for:
    - CDI device
    - GPU
    - Conflict validation
  - Added check in tests to skip them if a NVIDIA GPU is not found.