### PR TITLE
fix(buildx): Recreate builder if deleted out-of-band

### DIFF
--- a/internal/provider/resource_docker_buildx_builder.go
+++ b/internal/provider/resource_docker_buildx_builder.go
@@ -539,8 +539,15 @@ func resourceDockerBuildxBuilderRead(ctx context.Context, d *schema.ResourceData
 		builder.WithSkippedValidation(),
 	)
 	if err != nil {
+		log.Printf("[DEBUG] Failed to read Buildx builder %s: %v", name, err)
+		if strings.Contains(err.Error(), fmt.Sprintf("no builder \"%s\" found", name)) {
+			log.Printf("[DEBUG] Buildx builder %s not found, removing from state", name)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
+
 	return nil
 }
 

--- a/internal/provider/resource_docker_buildx_builder_test.go
+++ b/internal/provider/resource_docker_buildx_builder_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -16,6 +17,36 @@ func TestAccDockerBuildxBuilder_DockerContainerDriver(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("docker_buildx_builder.foo", "name"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDockerBuildxBuilder_OutOfBandDeletion(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: loadTestConfiguration(t, RESOURCE, "docker_buildx_builder", "testAccDockerBuildxBuilderDockerContainer"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("docker_buildx_builder.foo", "name"),
+				),
+			},
+			{
+				// This step simulates the external deletion or non-existence of the resource
+				PreConfig: func() {
+					if err := exec.Command("docker", "buildx", "rm", "foo").Run(); err != nil {
+						t.Fatalf("failed to delete resource externally: %v", err)
+					}
+				},
+				PlanOnly: true,
+				Config:   loadTestConfiguration(t, RESOURCE, "docker_buildx_builder", "testAccDockerBuildxBuilderDockerContainer"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("docker_buildx_builder.foo", "name", "test"),
+				),
+				// We expect the plan to show that the resource will be recreated because it was deleted out-of-band
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
Fixes #779 in a much simpler way