### PR TITLE
Feature: provide a full docker image name + sha256 digest for more stable pull operations

### DIFF
--- a/docs/data-sources/registry_image.md
+++ b/docs/data-sources/registry_image.md
@@ -38,3 +38,4 @@ resource "docker_image" "ubuntu" {
 
 - `id` (String) The ID of this resource.
 - `sha256_digest` (String) The content digest of the image, as stored in the registry.
+- `pull_by_digest` (String) The sha256 name of the image, for example: `registry.tld/image-name@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30`

--- a/docs/resources/registry_image.md
+++ b/docs/resources/registry_image.md
@@ -48,6 +48,7 @@ resource "docker_image" "image" {
 
 - `id` (String) The ID of this resource.
 - `sha256_digest` (String) The sha256 digest of the image.
+- `pull_by_digest` (String) The sha256 name of the image, for example: `registry.tld/image-name@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30`
 
 <a id="nestedblock--auth_config"></a>
 ### Nested Schema for `auth_config`

--- a/internal/provider/data_source_docker_registry_image.go
+++ b/internal/provider/data_source_docker_registry_image.go
@@ -30,6 +30,19 @@ func dataSourceDockerRegistryImage() *schema.Resource {
 				Computed:    true,
 			},
 
+			"pull_by_digest": {
+				Type: schema.TypeString,
+				Description: `The computed image name and sha256 digest put together.
+
+This will be something like ` + "`your-registry.tld/your-image@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30`" + `.
+
+This value is reliable to prevent common issues, such as:
+
+* downstream resources not being re-computed due to a tag name not changing
+* downstream resources being recomputed, even if the docker image didn't change at all`,
+				Computed: true,
+			},
+
 			"insecure_skip_verify": {
 				Type:        schema.TypeBool,
 				Description: "If `true`, the verification of TLS certificates of the server/registry is disabled. Defaults to `false`",

--- a/internal/provider/data_source_docker_registry_image_test.go
+++ b/internal/provider/data_source_docker_registry_image_test.go
@@ -24,6 +24,7 @@ func TestAccDockerRegistryImage_basic(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, DATA_SOURCE, "docker_registry_image", "testAccDockerImageDataSourceConfig"), "alpine:latest"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.docker_registry_image.foo", "sha256_digest", registryDigestRegexp),
+					resource.TestMatchResourceAttr("data.docker_registry_image.foo", "pull_by_digest", regexp.MustCompile(`\Aalpine@sha256:[A-Za-z0-9_\+\.-]+:[A-Fa-f0-9]+\z`)),
 				),
 			},
 		},
@@ -39,6 +40,7 @@ func TestAccDockerRegistryImage_basicWithDigest(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, DATA_SOURCE, "docker_registry_image", "testAccDockerImageDataSourceConfig"), "nginx:1.28.0@sha256:eaa7e36decc3421fc04478c586dfea0d931cebe47d5bc0b15d758a32ba51126f"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.docker_registry_image.foo", "sha256_digest", "sha256:eaa7e36decc3421fc04478c586dfea0d931cebe47d5bc0b15d758a32ba51126f"),
+					resource.TestCheckResourceAttr("data.docker_registry_image.foo", "pull_by_digest", "nginx:1.28.0@sha256:eaa7e36decc3421fc04478c586dfea0d931cebe47d5bc0b15d758a32ba51126f"),
 				),
 			},
 		},
@@ -54,6 +56,7 @@ func TestAccDockerRegistryImage_private(t *testing.T) {
 				Config: loadTestConfiguration(t, DATA_SOURCE, "docker_registry_image", "testAccDockerImageDataSourcePrivateConfig"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.docker_registry_image.bar", "sha256_digest", registryDigestRegexp),
+					resource.TestMatchResourceAttr("data.docker_registry_image.bar", "pull_by_digest", regexp.MustCompile(`\A.*@sha256:[A-Za-z0-9_\+\.-]+:[A-Fa-f0-9]+\z`)),
 				),
 			},
 		},
@@ -72,6 +75,7 @@ func TestAccDockerRegistryImage_WithoutDaemon(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, DATA_SOURCE, "docker_registry_image", "testAccDockerImageDataSource_WithoutDaemon"), registry, image),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.docker_registry_image.foobar", "sha256_digest", registryDigestRegexp),
+					resource.TestMatchResourceAttr("data.docker_registry_image.foobar", "pull_by_digest", regexp.MustCompile(`\A127\.0\.0\.1:15000/tftest-service@sha256:[A-Za-z0-9_\+\.-]+:[A-Fa-f0-9]+\z`)),
 				),
 			},
 		},
@@ -92,6 +96,7 @@ func TestAccDockerRegistryImage_auth(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, DATA_SOURCE, "docker_registry_image", "testAccDockerImageDataSourceAuthConfig"), registry, image),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.docker_registry_image.foobar", "sha256_digest", registryDigestRegexp),
+					resource.TestMatchResourceAttr("data.docker_registry_image.foobar", "pull_by_digest", regexp.MustCompile(`\A127\.0\.0\.1:15000/tftest-service@sha256:[A-Za-z0-9_\+\.-]+:[A-Fa-f0-9]+\z`)),
 				),
 			},
 		},
@@ -113,6 +118,7 @@ func TestAccDockerRegistryImage_httpAuth(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, DATA_SOURCE, "docker_registry_image", "testAccDockerImageDataSourceAuthConfig"), registry, image),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.docker_registry_image.foobar", "sha256_digest", registryDigestRegexp),
+					resource.TestMatchResourceAttr("data.docker_registry_image.foobar", "pull_by_digest", regexp.MustCompile(`\A127\.0\.0\.1:150001/tftest-service@sha256:[A-Za-z0-9_\+\.-]+:[A-Fa-f0-9]+\z`)),
 				),
 			},
 		},

--- a/internal/provider/resource_docker_registry_image.go
+++ b/internal/provider/resource_docker_registry_image.go
@@ -62,6 +62,19 @@ func resourceDockerRegistryImage() *schema.Resource {
 				Computed:    true,
 			},
 
+			"pull_by_digest": {
+				Type: schema.TypeString,
+				Description: `The computed image name and sha256 digest put together.
+
+This will be something like ` + "`your-registry.tld/your-image@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30`" + `.
+
+This value is reliable to prevent common issues, such as:
+
+* downstream resources not being re-computed due to a tag name not changing
+* downstream resources being recomputed, even if the docker image didn't change at all`,
+				Computed: true,
+			},
+
 			"auth_config": AuthConfigSchema,
 			"build": {
 				Type:        schema.TypeSet,

--- a/internal/provider/resource_docker_registry_image_funcs.go
+++ b/internal/provider/resource_docker_registry_image_funcs.go
@@ -76,6 +76,7 @@ func resourceDockerRegistryImageCreate(ctx context.Context, d *schema.ResourceDa
 	}
 	d.SetId(digest)
 	d.Set("sha256_digest", digest)
+	d.Set("pull_by_digest", fmt.Sprintf("%s@%s", name, digest))
 	return nil
 }
 

--- a/internal/provider/resource_docker_registry_image_test.go
+++ b/internal/provider/resource_docker_registry_image_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+var digestImageRegexp = regexp.MustCompile(`\A127\.0\.0\.1:1500[0-1]tftest-dockerregistryimage@sha256:[A-Za-z0-9_\+\.-]+:[A-Fa-f0-9]+\z`)
+
 func TestAccDockerRegistryImageResource_build_insecure_registry(t *testing.T) {
 	pushOptions := createPushImageOptions("127.0.0.1:15001/tftest-dockerregistryimage:1.0")
 	wd, _ := os.Getwd()
@@ -24,6 +26,7 @@ func TestAccDockerRegistryImageResource_build_insecure_registry(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, RESOURCE, "docker_registry_image", "testBuildDockerRegistryImageNoKeepConfig"), "http://127.0.0.1:15001", pushOptions.Name, context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("docker_registry_image.foo", "sha256_digest"),
+					resource.TestMatchResourceAttr("docker_registry_image.foo", "pull_by_digest", digestImageRegexp),
 				),
 			},
 		},
@@ -44,6 +47,7 @@ func TestAccDockerRegistryImageResource_buildAndKeep(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, RESOURCE, "docker_registry_image", "testBuildDockerRegistryImageKeepConfig"), pushOptions.Registry, pushOptions.Name, context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("docker_registry_image.foo", "sha256_digest"),
+					resource.TestMatchResourceAttr("docker_registry_image.foo", "pull_by_digest", digestImageRegexp),
 				),
 			},
 		},
@@ -65,6 +69,7 @@ func TestAccDockerRegistryImageResource_directBuildAndKeep(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, RESOURCE, "docker_registry_image", "testDirectBuildDockerRegistryImageKeepConfig"), pushOptions.Registry, pushOptions.Name, context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("docker_registry_image.foo", "sha256_digest"),
+					resource.TestMatchResourceAttr("docker_registry_image.foo", "pull_by_digest", digestImageRegexp),
 				),
 			},
 		},
@@ -100,6 +105,7 @@ func TestAccDockerRegistryImageResource_withAuthConfig(t *testing.T) {
 				Config: fmt.Sprintf(loadTestConfiguration(t, RESOURCE, "docker_registry_image", "testBuildDockerRegistryImageWithAuthConfig"), pushOptions.Name, context, pushOptions.Registry, "testuser", "testpwd"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("docker_registry_image.foo", "sha256_digest"),
+					resource.TestMatchResourceAttr("docker_registry_image.foo", "pull_by_digest", digestImageRegexp),
 				),
 			},
 		},


### PR DESCRIPTION
This change provides new properties (names pending review):

* `docker_registry_image.pull_by_digest`
* `data.docker_registry_image.pull_by_digest`

These properties are aimed at reducing docker image drifting, shifting downstream consumers from using docker image tags (often mutable/unreliable) to using the sha256 digest of an image for `pull` operations.

The aim is:

* prevent common issues, such as services not pulling new images (because of common `:v1` or `:latest` usage mistakes)
* prevent downstream services from restarting, when nothing in an image changed (such as `v1.2.3` -> `v1.2.4` without image changes)