### PR TITLE
fix(container): normalize port IPs and stabilize port ordering for dual-stack bindings

### DIFF
--- a/internal/provider/resource_docker_container.go
+++ b/internal/provider/resource_docker_container.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -513,12 +512,7 @@ func resourceDockerContainer() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							StateFunc: func(val interface{}) string {
-								// Empty IP assignments default to 0.0.0.0
-								if val.(string) == "" {
-									return "0.0.0.0"
-								}
-
-								return val.(string)
+								return normalizePortIP(val.(string))
 							},
 						},
 
@@ -1192,69 +1186,39 @@ func resourceDockerContainer() *schema.Resource {
 func suppressIfPortsDidNotChangeForMigrationV0ToV1() schema.SchemaDiffSuppressFunc {
 	return func(k, old, new string, d *schema.ResourceData) bool {
 		if k == "ports.#" && old != new {
-			log.Printf("[DEBUG] suppress diff ports: old and new don't have the same length")
 			return false
 		}
 		portsOldRaw, portsNewRaw := d.GetChange("ports")
 		portsOld := portsOldRaw.([]interface{})
 		portsNew := portsNewRaw.([]interface{})
 		if len(portsOld) != len(portsNew) {
-			log.Printf("[DEBUG] suppress diff ports: old and new don't have the same length")
 			return false
 		}
-		log.Printf("[DEBUG] suppress diff ports: old and new have same length")
 
+		// Match each old port to a new port by all fields, tracking which
+		// new ports have already been consumed to handle duplicates correctly.
+		matched := make([]bool, len(portsNew))
 		for _, portOld := range portsOld {
 			portOldMapped := portOld.(map[string]interface{})
-			oldInternalPort := portOldMapped["internal"]
 			portFound := false
-			for _, portNew := range portsNew {
+			for j, portNew := range portsNew {
+				if matched[j] {
+					continue
+				}
 				portNewMapped := portNew.(map[string]interface{})
-				newInternalPort := portNewMapped["internal"]
-				// port is still there in new
-				if newInternalPort == oldInternalPort {
-					log.Printf("[DEBUG] suppress diff ports: comparing port '%v'", oldInternalPort)
-					if portNewMapped["protocol"] != portOldMapped["protocol"] {
-						if containsPortWithProtocol(portsNew, portOldMapped["internal"], portOldMapped["protocol"]) {
-							log.Printf("[DEBUG] suppress diff ports: found another port in new list with the same protocol for '%v", oldInternalPort)
-							continue
-						}
-
-						log.Printf("[DEBUG] suppress diff ports: 'protocol' changed for '%v'", oldInternalPort)
-						return false
-					}
-					if portNewMapped["external"] != portOldMapped["external"] {
-						log.Printf("[DEBUG] suppress diff ports: 'external' changed for '%v'", oldInternalPort)
-						return false
-					}
-					if portNewMapped["ip"] != portOldMapped["ip"] {
-						log.Printf("[DEBUG] suppress diff ports: 'ip' changed for '%v'", oldInternalPort)
-						return false
-					}
-
+				if portNewMapped["internal"] == portOldMapped["internal"] &&
+					portNewMapped["external"] == portOldMapped["external"] &&
+					portNewMapped["protocol"] == portOldMapped["protocol"] &&
+					normalizePortIP(portNewMapped["ip"].(string)) == normalizePortIP(portOldMapped["ip"].(string)) {
+					matched[j] = true
 					portFound = true
 					break
 				}
 			}
-			// port was deleted or exchanges in new
 			if !portFound {
-				log.Printf("[DEBUG] suppress diff ports: port was deleted '%v'", oldInternalPort)
 				return false
 			}
 		}
 		return true
 	}
-}
-
-func containsPortWithProtocol(ports []interface{}, searchInternalPort, searchProtocol interface{}) bool {
-	for _, port := range ports {
-		portMapped := port.(map[string]interface{})
-		internalPort := portMapped["internal"]
-		protocol := portMapped["protocol"]
-		if internalPort == searchInternalPort && protocol == searchProtocol {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/provider/resource_docker_container_structures.go
+++ b/internal/provider/resource_docker_container_structures.go
@@ -32,6 +32,18 @@ func (s byPortAndProtocol) Less(i, j int) bool {
 	return iPort < jPort
 }
 
+// normalizePortIP normalizes port IP addresses for consistent comparison.
+// It strips brackets from IPv6 addresses (e.g., "[::]" -> "::") and
+// defaults empty strings to "0.0.0.0".
+func normalizePortIP(ip string) string {
+	if ip == "" {
+		return "0.0.0.0"
+	}
+	ip = strings.TrimPrefix(ip, "[")
+	ip = strings.TrimSuffix(ip, "]")
+	return ip
+}
+
 func flattenContainerPorts(in nat.PortMap) []interface{} {
 	out := make([]interface{}, 0)
 
@@ -43,6 +55,9 @@ func flattenContainerPorts(in nat.PortMap) []interface{} {
 
 	for _, portKey := range internalPortKeys {
 		portBindings := in[nat.Port(portKey)]
+		sort.Slice(portBindings, func(i, j int) bool {
+			return normalizePortIP(portBindings[i].HostIP) < normalizePortIP(portBindings[j].HostIP)
+		})
 		for _, portBinding := range portBindings {
 			m := make(map[string]interface{})
 			portProtocolSplit := strings.Split(string(portKey), "/")
@@ -50,7 +65,7 @@ func flattenContainerPorts(in nat.PortMap) []interface{} {
 			convertedExternal, _ := strconv.Atoi(portBinding.HostPort)
 			m["internal"] = convertedInternal
 			m["external"] = convertedExternal
-			m["ip"] = portBinding.HostIP
+			m["ip"] = normalizePortIP(portBinding.HostIP)
 			m["protocol"] = portProtocolSplit[1]
 			out = append(out, m)
 		}

--- a/internal/provider/resource_docker_container_structures_test.go
+++ b/internal/provider/resource_docker_container_structures_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -185,6 +186,114 @@ func TestFlattenDevices(t *testing.T) {
 		second := got[1].(map[string]interface{})
 		if second["container_path"] != "/dev/container1" {
 			t.Fatalf("expected second device container_path to be preserved, got %#v", second["container_path"])
+		}
+	})
+}
+
+func TestNormalizePortIP(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty defaults to 0.0.0.0", input: "", expected: "0.0.0.0"},
+		{name: "ipv4 unchanged", input: "0.0.0.0", expected: "0.0.0.0"},
+		{name: "ipv4 specific unchanged", input: "192.168.1.1", expected: "192.168.1.1"},
+		{name: "ipv6 bare unchanged", input: "::", expected: "::"},
+		{name: "ipv6 bracketed stripped", input: "[::]", expected: "::"},
+		{name: "ipv6 full bracketed stripped", input: "[::1]", expected: "::1"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizePortIP(tc.input)
+			if got != tc.expected {
+				t.Fatalf("normalizePortIP(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestFlattenContainerPorts(t *testing.T) {
+	t.Run("normalizes IPv6 IPs from API", func(t *testing.T) {
+		portMap := nat.PortMap{
+			"80/tcp": []nat.PortBinding{
+				{HostIP: "0.0.0.0", HostPort: "80"},
+				{HostIP: "::", HostPort: "80"},
+			},
+		}
+
+		got := flattenContainerPorts(portMap)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 ports, got %d", len(got))
+		}
+
+		first := got[0].(map[string]interface{})
+		if first["ip"] != "0.0.0.0" {
+			t.Fatalf("expected first port ip to be 0.0.0.0, got %q", first["ip"])
+		}
+		second := got[1].(map[string]interface{})
+		if second["ip"] != "::" {
+			t.Fatalf("expected second port ip to be ::, got %q", second["ip"])
+		}
+	})
+
+	t.Run("sorts bindings by IP within same port", func(t *testing.T) {
+		portMap := nat.PortMap{
+			"80/tcp": []nat.PortBinding{
+				{HostIP: "::", HostPort: "80"},
+				{HostIP: "0.0.0.0", HostPort: "80"},
+			},
+		}
+
+		got := flattenContainerPorts(portMap)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 ports, got %d", len(got))
+		}
+
+		first := got[0].(map[string]interface{})
+		if first["ip"] != "0.0.0.0" {
+			t.Fatalf("expected first port ip to be 0.0.0.0 (sorted), got %q", first["ip"])
+		}
+		second := got[1].(map[string]interface{})
+		if second["ip"] != "::" {
+			t.Fatalf("expected second port ip to be :: (sorted), got %q", second["ip"])
+		}
+	})
+
+	t.Run("sorts by port then by IP", func(t *testing.T) {
+		portMap := nat.PortMap{
+			"443/tcp": []nat.PortBinding{
+				{HostIP: "::", HostPort: "443"},
+				{HostIP: "0.0.0.0", HostPort: "443"},
+			},
+			"80/tcp": []nat.PortBinding{
+				{HostIP: "::", HostPort: "80"},
+				{HostIP: "0.0.0.0", HostPort: "80"},
+			},
+		}
+
+		got := flattenContainerPorts(portMap)
+		if len(got) != 4 {
+			t.Fatalf("expected 4 ports, got %d", len(got))
+		}
+
+		expected := []struct {
+			internal int
+			ip       string
+		}{
+			{80, "0.0.0.0"},
+			{80, "::"},
+			{443, "0.0.0.0"},
+			{443, "::"},
+		}
+
+		for i, exp := range expected {
+			m := got[i].(map[string]interface{})
+			if m["internal"] != exp.internal || m["ip"] != exp.ip {
+				t.Fatalf("port[%d]: expected internal=%d ip=%q, got internal=%v ip=%v",
+					i, exp.internal, exp.ip, m["internal"], m["ip"])
+			}
 		}
 	})
 }


### PR DESCRIPTION
Containers with dual-stack port bindings (0.0.0.0 and ::) were flagged for replacement on every apply due to non-deterministic port ordering from the Docker API and incorrect diff suppression matching.

- Add normalizePortIP to strip IPv6 brackets and default empty to 0.0.0.0
- Sort port bindings by IP within each port in flattenContainerPorts
- Rewrite diff suppression to match by all port fields, not just internal
- Apply IP normalization in StateFunc and when reading state from API

Fixes #909